### PR TITLE
docs: add closing string quote and use code blocks

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,7 +8,7 @@ To use datawrapper in a project::
 
     from datawrapper import Datawrapper
 
-    dw = Datawrapper(access_token = "INSERT_YOUR_ACCESS_TOKEN_HERE)
+    dw = Datawrapper(access_token = "INSERT_YOUR_ACCESS_TOKEN_HERE")
 
 Now you have access to your Datawrapper account.
 
@@ -20,10 +20,12 @@ Create a chart
 
 This returns a JSON with your new chart's info, including its ID which you will need to update, add data to, move, display or delete said chart.
 
-You could also pass a pandas.DataFrame as data in the same call and you'll have created a chart and uploaded the data at once.
+You could also pass a pandas.DataFrame as data in the same call and you'll have created a chart and uploaded the data at once. 
+::
     df = pd.read_csv("https://raw.githubusercontent.com/chekos/datasets/master/data/datawrapper_example.csv", sep=';')
     new_chart_info = dw.create_chart(title = 'New chart 2!', chart_type = 'd3-bars-stacked', data  = df)
     new_chart_info
+    
     >>>> {'title': 'New chart 2!',
             'theme': 'default',
             'type': 'd3-bars-stacked',
@@ -38,6 +40,7 @@ You could also pass a pandas.DataFrame as data in the same call and you'll have 
 Your chart will have a different 'id'. That is super important because that's how you edit your chart!
 
 Update the chart's description:
+::
     dw.update_description(
         chart_id = new_chart_info['id'],
         source_name = 'UN Population Division',
@@ -47,6 +50,7 @@ Update the chart's description:
     >>>> Chart updated!
 
 For others to see your marvelous creation you need to publish your chart!
+::
     dw.publish_chart(chart_id = new_chart_info['id'])
 
 By default, `datawrapper` (the python package) will attempt to display your chart as the cell's output. This feature is still being tested so it might be changed to not do this by default in the future.


### PR DESCRIPTION
Thank you for creating this library. While reading I noticed a tiny error about the access token.

I'm not sure if the code block change will work in the generated documentation (it does on Github). Let me know if I should remove something.