### PR TITLE
Body of PUT request is encoded into UTF-8

### DIFF
--- a/datawrapper/datawrapper.py
+++ b/datawrapper/datawrapper.py
@@ -61,7 +61,7 @@ class Datawrapper:
         """
         Adds data to a chart, table, map.
         Arguments:
-            id (str): Chart, table or map id.
+            chart_id (str): Chart, table or map id.
             data (pandas.DataFrame): a DataFrame containing the data to be added.
         """
         _header = self._auth_header
@@ -70,7 +70,7 @@ class Datawrapper:
         _data = data.to_csv(index=False, encoding="utf-8")
 
         add_data_response = r.put(
-            url=f"{self._CHARTS_URL}/{chart_id}/data", headers=_header, data=_data
+            url=f"{self._CHARTS_URL}/{chart_id}/data", headers=_header, data=_data.encode('utf-8')
         )
         return add_data_response
 


### PR DESCRIPTION
Hello!
There is an issue with `add_data` method now - the `requests` module breaks when you try to send request body with cyrillics or other non-ASCII symbols without encoding it preliminarily. So I fixed it.  
BTW, thanks for the module!