### PR TITLE
Add the `zoom` export parameter to the relevant method

### DIFF
--- a/datawrapper/datawrapper.py
+++ b/datawrapper/datawrapper.py
@@ -1,6 +1,6 @@
 """Access Datawrapper's API to create, update, delete charts.
 
-Datawrapper API lets you programatically interface with your charts. 
+Datawrapper API lets you programatically interface with your charts.
 It lets you create and edit charts, update your account information and many more things to come.
 
     This package is a light-weight wrapper around Datawrapper's API.
@@ -22,7 +22,7 @@ class Datawrapper:
     """Handles connecting with Datawrapper's API.
 
     Handles access to your Datawrapper's account, create, delete and move charts, tables or maps.
-    Will attempt to read environment variable DATAWRAPPER_ACCESS_TOKEN by default. 
+    Will attempt to read environment variable DATAWRAPPER_ACCESS_TOKEN by default.
 
     Args:
         access_token: A personal access token to use the API. See app.datawrapper.de/account/api-tokens.
@@ -87,7 +87,7 @@ class Datawrapper:
             title (str): Title for new chart, table or map.
             chart_type (str): Chart type to be created. See https://developer.datawrapper.de/docs/chart-types.
             data (pandas.DataFrame): Optional. A DataFrame containing the data to be added.
-            folder_id (str): Datawrapper folder id for the chart, table or map to be created at. 
+            folder_id (str): Datawrapper folder id for the chart, table or map to be created at.
         """
         _header = self._auth_header
         _header["content-type"] = "application/json"
@@ -268,7 +268,7 @@ class Datawrapper:
             chart_id (str): Chart, table or map id to display.
         Returns:
             IPython.display.HTML output with chart's iframe-embed code.
-        
+
         Interactivity may be limited as it is assumed it is being displayed within a Jupyter notebook environment.
         """
         _chart_properties = self.chart_properties(chart_id)
@@ -305,6 +305,7 @@ class Datawrapper:
         mode="rgb",
         width=None,
         plain=False,
+        zoom=2,
         scale=1,
         border_width=20,
         output="png",
@@ -321,9 +322,10 @@ class Datawrapper:
             mode (str): One of rgb or cmyk. Which color mode the output should be in. Default is rgb.
             width (int): Width of visualization. If not specified, it takes the chart width.
             plain (bool): Defines if only the visualization should be exported (True), or if it should include header and footer as well (False).
-            scale (int): Defines the multiplier for the size.
+            zoom (int): Defines the multiplier for the png size.
+            scale (int): Defines the multiplier for the pdf size.
             border_width (int): Margin around the visualization. E.g., a borderWidth of 20px gives the visualization a 20px margin.
-            output (str): one of png, pdf, or svg. 
+            output (str): one of png, pdf, or svg.
             filepath (str): Name/filepath to save output in.
             display (bool): Whether to display the exported image.
         """
@@ -337,6 +339,7 @@ class Datawrapper:
             "mode": mode,
             "width": width,
             "plain": plain,
+            "zoom": zoom,
             "scale": scale,
             "borderWidth": border_width,
         }


### PR DESCRIPTION
Hi! 😄 

I was using this package (thanks!) yesterday and noticed that the `export_chart()` method does not have a parameter for the `zoom` one, according to the [Datawrapper documentation](https://developer.datawrapper.de/docs/exporting-as-pdfsvg). If I understand correctly, this parameter is basically what allows you to "scale" the images in PNG format, in order to generate images with better quality/resolution, while the `scale` parameter is for the PDF format.

In this way, this PR, if considered relevant, simply adds a new parameter (`zoom`) to the `export_chart()` method, in order to be able to customize the scale when exporting PNGs (there were also some whitespaces removed when I saved the file, but since they were small adjustments, I thought about keeping them — I hope it is ok). I also tested this approach [here](https://github.com/joaopalmeiro/datavis-python-playground/tree/master/datawrapper-api) (with a monkey patch).

Feel free to ask for clarification or to suggest changes. I hope this tiny PR can be useful! 😄 