### PR TITLE
Fix for create_chart requests without folder_id paramter defined

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -154,7 +154,7 @@ class Datawrapper:
         _data = {"title": title, "type": chart_type}
 
         if folder_id:
-            _data['folderId'] = folder_id
+            _data["folderId"] = folder_id
 
         new_chart_response = r.post(
             url=self._CHARTS_URL, headers=_header, data=json.dumps(_data)

--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -151,7 +151,10 @@ class Datawrapper:
         _header = self._auth_header
         _header["content-type"] = "application/json"
 
-        _data = {"title": title, "type": chart_type, "folderId": folder_id}
+        _data = {"title": title, "type": chart_type}
+
+        if folder_id:
+            _data['folderId'] = folder_id
 
         new_chart_response = r.post(
             url=self._CHARTS_URL, headers=_header, data=json.dumps(_data)
@@ -174,7 +177,7 @@ class Datawrapper:
             print(f"New chart {chart_info['type']} created!")
         else:
             print(
-                "Chart could not be created, check your authorization credentials (access token)"
+                f"Chart could not be created, check your authorization credentials (access token){', and that the folder_id is valid (i.e exists, and your account has access to it)' if folder_id else ''}"
             )
 
         if data is not None:


### PR DESCRIPTION
## Description

This is a proposed fix for [issue #61](https://github.com/chekos/Datawrapper/issues/61).

**Context**
Recently there were changes made to the Datawrapper API, whereby `POST /charts` requests (to create a new chart) now return a `403` if the folder sent in the payload is invalid. i.e if it either:
- doesn't exist
- the requesting user doesn't have access to it
- it conflicts with the `organizationId` (i.e corresponds to a folder that isn't in that team/organization)

The current implementation in this library is such that if the user doesn't specify a `folder_id` it gets sent along with the create request as an empty string, which is invalid, so Datawrapper returns a `403` and the chart doesn't get created.

**Changes**
- Only pass `folderId` along with the `POST /charts` request if the user specified it in their call of `create_chart`.
- Extend print output when 403 is returned and a `folder_id` was defined, that suggests that the folder_id may be the issue

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/chekos/datawrapper/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/chekos/datawrapper/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
~-I've written tests for all new methods and classes that I created.~
~- I've written the docstring in Google format for all the methods and classes that I used.~

I had to commit with `--no-verify` because of a failing commit hook, that I unfortunately couldn't figure out how to solve (pretty new to Python, sorry 🙈)

```
An unexpected error has occurred: CalledProcessError: command: ('/Users/elana/Library/Caches/pypoetry/virtualenvs/datawrapper-rDpTQou8-py3.9/bin/python', '-mvirtualenv', '/Users/elana/.cache/pre-commit/repo4o2s4ioq/py_env-python3.7', '-p', 'python3.7')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.7'
```