### PR TITLE
add folder_id param to get_charts

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -604,6 +604,7 @@ class Datawrapper:
         search: str = "",
         order: str = "DESC",
         order_by: str = "createdAt",
+        folder_id: str = "",
         limit: int = 25,
     ) -> Union[None, List[Any]]:
         """Retrieves a list of charts by User
@@ -620,6 +621,8 @@ class Datawrapper:
             Result order (ascending or descending), by default "DESC"
         order_by : str, optional
             Attribute to order by. One of createdAt, email, id, or name, by default "createdAt"
+        folder_id: str, optional
+            ID of the folder to search charts in, by default ""
         limit : int, optional
             Maximum items to fetch, by default 25
 
@@ -643,6 +646,8 @@ class Datawrapper:
             _query["order"] = order
         if order_by:
             _query["orderBy"] = order_by
+        if folder_id:
+            _query["folderId"] = folder_id
         if limit:
             _query["limit"] = str(limit)
 


### PR DESCRIPTION
## Description

Add folder_id param in get_charts method so we can get charts inside a specific folder_id

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/chekos/datawrapper/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/chekos/datawrapper/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
