### PR TITLE
allow metadata in create_chart()

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -126,6 +126,7 @@ class Datawrapper:
         chart_type: str = "d3-bars-stacked",
         data: Union[pd.DataFrame, None] = None,
         folder_id: str = "",
+        metadata: Dict[Any, Any] = None,
     ) -> Union[Dict[Any, Any], None, Any]:
         """Creates a new Datawrapper chart, table or map.
         You can pass a pandas DataFrame as a `data` argument to upload data.
@@ -141,6 +142,8 @@ class Datawrapper:
             A pandas DataFrame containing the data to be added, by default None
         folder_id : str, optional
             ID of folder in Datawrapper.de for the chart, table or map to be created in, by default ""
+        metadata: dict, optional
+            A Python dictionary of properties to add.
 
         Returns
         -------
@@ -155,6 +158,8 @@ class Datawrapper:
 
         if folder_id:
             _data["folderId"] = folder_id
+        if metadata:
+            _data["metadata"] = metadata
 
         new_chart_response = r.post(
             url=self._CHARTS_URL, headers=_header, data=json.dumps(_data)


### PR DESCRIPTION
## Description

Allow adding a metadata object in `create_chart()` method, thus avoiding having to do another API call with `update_metadata()` for initial metadata.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/chekos/datawrapper/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/chekos/datawrapper/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
