### PR TITLE
Allow organization id on create chart

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -610,6 +610,8 @@ class Datawrapper:
         order: str = "DESC",
         order_by: str = "createdAt",
         limit: int = 25,
+        folder_id: str = "",
+        team_id: str = "",
     ) -> Union[None, List[Any]]:
         """Retrieves a list of charts by User
 
@@ -627,6 +629,10 @@ class Datawrapper:
             Attribute to order by. One of createdAt, email, id, or name, by default "createdAt"
         limit : int, optional
             Maximum items to fetch, by default 25
+        folder_id : str, optional
+            ID of folder in Datawrapper.de where to list charts, by default ""
+        team_id : str, optional
+            ID of the team where to list charts. The authenticated user must have access to this team, by default ""
 
         Returns
         -------
@@ -650,6 +656,10 @@ class Datawrapper:
             _query["orderBy"] = order_by
         if limit:
             _query["limit"] = str(limit)
+        if folder_id:
+            _data["folderId"] = folder_id
+        if team_id:
+            _data["teamId"] = team_id
 
         get_charts_response = r.get(url=_url, headers=_header, params=_query)
 

--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -126,6 +126,7 @@ class Datawrapper:
         chart_type: str = "d3-bars-stacked",
         data: Union[pd.DataFrame, None] = None,
         folder_id: str = "",
+        organization_id: str = "",
     ) -> Union[Dict[Any, Any], None, Any]:
         """Creates a new Datawrapper chart, table or map.
         You can pass a pandas DataFrame as a `data` argument to upload data.
@@ -141,6 +142,8 @@ class Datawrapper:
             A pandas DataFrame containing the data to be added, by default None
         folder_id : str, optional
             ID of folder in Datawrapper.de for the chart, table or map to be created in, by default ""
+        organization_id : str, optional
+            ID of the team where the chart should be created. The authenticated user must have access to this team.
 
         Returns
         -------
@@ -155,6 +158,8 @@ class Datawrapper:
 
         if folder_id:
             _data["folderId"] = folder_id
+        if organization_id:
+            _data["organizationId"] = organization_id
 
         new_chart_response = r.post(
             url=self._CHARTS_URL, headers=_header, data=json.dumps(_data)

--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -662,9 +662,9 @@ class Datawrapper:
         if limit:
             _query["limit"] = str(limit)
         if folder_id:
-            _data["folderId"] = folder_id
+            _query["folderId"] = folder_id
         if team_id:
-            _data["teamId"] = team_id
+            _query["teamId"] = team_id
 
         get_charts_response = r.get(url=_url, headers=_header, params=_query)
 

--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -614,7 +614,6 @@ class Datawrapper:
         search: str = "",
         order: str = "DESC",
         order_by: str = "createdAt",
-        folder_id: str = "",
         limit: int = 25,
         folder_id: str = "",
         team_id: str = "",
@@ -633,8 +632,6 @@ class Datawrapper:
             Result order (ascending or descending), by default "DESC"
         order_by : str, optional
             Attribute to order by. One of createdAt, email, id, or name, by default "createdAt"
-        folder_id: str, optional
-            ID of the folder to search charts in, by default ""
         limit : int, optional
             Maximum items to fetch, by default 25
         folder_id : str, optional
@@ -662,8 +659,6 @@ class Datawrapper:
             _query["order"] = order
         if order_by:
             _query["orderBy"] = order_by
-        if folder_id:
-            _query["folderId"] = folder_id
         if limit:
             _query["limit"] = str(limit)
         if folder_id:


### PR DESCRIPTION
## Description

Added team (organization) ID filter in `create_chart` method.
Added team and folder ID filters in `get_charts` method.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/chekos/datawrapper/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/chekos/datawrapper/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
