### PR TITLE
change post timeout to 30secs

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -203,7 +203,7 @@ class Datawrapper:
         self,
         url: str,
         data: dict | None = None,
-        timeout: int = 15,
+        timeout: int = 30,
         extra_headers: dict | None = None,
     ) -> dict | bool:
         """Make a POST request to the Datawrapper API.


### PR DESCRIPTION
## Update Post timeout

When trying to publish a choropleth map using `dw.publish_chart()` I was getting a timeout error, despite my API key having full permissions. I forked the repo, changed the timeout to 30 seconds, pip install'd the fork and re-ran the code and it worked. 

I'm suggesting you update the timeout to 30 seconds to allow for larger datasets/more complicated charts.