### PR TITLE
Fix None check in update_chart to work with DataFrames

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -809,7 +809,7 @@ class Datawrapper:
             obj = self.get_chart(chart_id)
 
         # Add data, if provided
-        if data:
+        if data is not None:
             self.add_data(chart_id=obj["id"], data=data)
 
         # Return the result


### PR DESCRIPTION
What we have now will fail if you submit a DataFrame, saying:

```
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```