### PR TITLE
Improve folder retrieval & filtering

### DIFF
--- a/tests/test_folders.py
+++ b/tests/test_folders.py
@@ -49,3 +49,36 @@ def test_folder_crud():
 
     # Delete both folders
     dw.delete_folder(folder_info["id"])
+
+
+def test_get_folders_no_charts():
+    """Test the get_folders method with charts=False."""
+    # Connect
+    dw = Datawrapper()
+    folder_list = dw.get_folders(charts=False)
+
+    # Verify initial structure
+    assert "list" in folder_list
+    assert isinstance(folder_list["list"], list)
+
+    # Ensure no chart data is included
+    valid_keys = {"id", "name", "folders"}
+    for folder in folder_list["list"]:
+        assert all(key in valid_keys for key in folder.keys())  # Ensures only valid keys exist
+
+
+def test_get_folder_by_name():
+    """Test the get_folder_by_name method."""
+    dw = Datawrapper()
+    folder_list = dw.get_folders(charts=False, timeout=30)  
+
+    # Get an actual folder name to test against
+    if folder_list["list"]:
+        existing_folder_name = folder_list["list"][0]["name"]  # First folder name
+
+        # Search for it using get_folder_by_name
+        folder_id = Datawrapper.get_folder_by_name(folder_list, existing_folder_name)
+
+        # Ensure a valid ID is returned
+        assert folder_id is not None
+        assert isinstance(folder_id, (int, str))  # ID should be an int or str


### PR DESCRIPTION
1) Added param in get_folders:
- (charts = False) returns only folder names, IDs and hierarchy without chart metadata, which suits better for teams with lots of nested folders.

2) New get_folder_by_name() method:
- Allows searching for a folder by name (substring match, case-insensitive) from the dict returned from get_folders().

3) Added respective tests (after passing).

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/chekos/datawrapper/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/chekos/datawrapper/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [X] I've written tests for all new methods and classes that I created.
- [X] I've written the docstring in Google format for all the methods and classes that I used.
