### PR TITLE
Fix prevent leaking http headers between requests

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -65,6 +65,11 @@ class Datawrapper:
 
     def _get_auth_header(self) -> dict:
         """Get the authentication header for the Datawrapper API.
+
+        Returns
+        -------
+        dict
+            The authentication header for the Datawrapper API.
         """
         return {"Authorization": f"Bearer {self._access_token}"}
 

--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -62,7 +62,11 @@ class Datawrapper:
         """
 
         self._access_token = access_token
-        self._auth_header = {"Authorization": f"Bearer {access_token}"}
+
+    def _get_auth_header(self) -> dict:
+        """Get the authentication header for the Datawrapper API.
+        """
+        return {"Authorization": f"Bearer {self._access_token}"}
 
     #
     # Web request methods
@@ -84,7 +88,7 @@ class Datawrapper:
             Whether the request was successful.
         """
         # Set the headers
-        headers = self._auth_header
+        headers = self._get_auth_header()
         headers["accept"] = "*/*"
 
         # Make the request
@@ -117,7 +121,7 @@ class Datawrapper:
             An object containing the response from the API.
         """
         # Set headers
-        headers = self._auth_header
+        headers = self._get_auth_header()
         headers["accept"] = "*/*"
 
         # Make the request
@@ -170,7 +174,7 @@ class Datawrapper:
             A dictionary containing the response from the API.
         """
         # Set headers
-        headers = self._auth_header
+        headers = self._get_auth_header()
         headers["accept"] = "*/*"
         headers["content-type"] = "application/json"
 
@@ -226,7 +230,7 @@ class Datawrapper:
             successful but did not return any data.
         """
         # Set headers
-        headers = self._auth_header
+        headers = self._get_auth_header()
         headers["accept"] = "*/*"
 
         # Add extra headers if provided
@@ -286,7 +290,7 @@ class Datawrapper:
             Whether the request was successful.
         """
         # Set headers
-        headers = self._auth_header
+        headers = self._get_auth_header()
         headers["accept"] = "*/*"
 
         # Add extra headers if provided

--- a/tests/test_get_auth_header.py
+++ b/tests/test_get_auth_header.py
@@ -1,0 +1,15 @@
+"""Test the auth header getter function."""
+from datawrapper import Datawrapper
+
+
+def test_get_auth_header():
+    """Test the auth header getter function."""
+    dw = Datawrapper(access_token="test-token")
+    auth_header = dw._get_auth_header()
+    assert auth_header["Authorization"] == f"Bearer {dw._access_token}"
+
+    auth_header["content-type"] = "text/csv"
+
+    second_auth_header = dw._get_auth_header()
+    # The auth header should not be modified
+    assert second_auth_header.get("content-type") is None


### PR DESCRIPTION
## Description

The internal variable `this._auth_header` is polluted with other headers (e.g. `'content-type'`) because of a pass-by-reference bug in various places, e.g. [here](https://github.com/chekos/Datawrapper/blob/5ccb52005c855749aa5d59593ff8779ce5fee3f1/datawrapper/__main__.py#L173-L175).

We can observe this with a tiny demo:

```python
import sys
from datawrapper import Datawrapper
from pprint import pprint
from copy import deepcopy

demo_data = "date, value, growth\n1929-09-01, 100.0, 1.0\n1929-10-01, 89.2, 0.892\n1929-11-01, 45.6, 0.456\n1930-01-01, 35.8, 0.358"

def print_class_config(dw):
    auth_header = deepcopy(dw._auth_header)
    auth_header["Authorization"] = "***REDACTED***"
    pprint(auth_header)


def show_header_leakage(demo_data, api_key):
    dw = Datawrapper(access_token=api_key)

    print("initial header config of the client:\n")
    print_class_config(dw)

    chart = dw.create_chart(
        title="just some test chart",
        chart_type="d3-scatter-plot",
        data=demo_data,
    )

    dw.update_chart(
        chart_id=chart["id"],
        data=demo_data,
    )

    print("\nafter updating the chart:\n")
    print_class_config(dw)


if __name__ == "__main__":
    if len(sys.argv) != 2:
        print("Usage: python test.py <API_KEY>")
        sys.exit(1)

    api_key = sys.argv[1]
    show_header_leakage(demo_data, api_key)

```
Note: To run this script you need to run `python demo.py <API_KEY>` with an API key that is valid for chart creation.

The output looks like this:

```
initial header config of the client:

{'Authorization': '***REDACTED***'}

after updating the chart:

{'Authorization': '***REDACTED***', 'accept': '*/*', 'content-type': 'text/csv'}
```

In this particular example, we call `add_data` ([through `update_chart`](https://github.com/chekos/Datawrapper/blob/5ccb52005c855749aa5d59593ff8779ce5fee3f1/datawrapper/__main__.py#L812-L813)), [which passes `extra_headers` to the `put` method](https://github.com/chekos/Datawrapper/blob/5ccb52005c855749aa5d59593ff8779ce5fee3f1/datawrapper/__main__.py#L1192-L1195). [`put` then sets these headers](https://github.com/chekos/Datawrapper/blob/5ccb52005c855749aa5d59593ff8779ce5fee3f1/datawrapper/__main__.py#L289-L294) in a way where they leak into the `_auth_header` variable and are still present after the request has been finished on the class instance. This is problematic, because when we use this instance to send further requests, these headers will still be present and sent on the subsequent request. One case where this happens is the [`publish_chart` method, which sends a plain `post` request](https://github.com/chekos/Datawrapper/blob/5ccb52005c855749aa5d59593ff8779ce5fee3f1/datawrapper/__main__.py#L1008) that will contain `'content-type': 'text/csv'` when called after `update_chart`.

While sending incorrect `Content-Type` headers may not currently cause issues, it is not officially supported by the Datawrapper API. Future changes to the API could lead to unexpected failures in this library if invalid headers are used.

Disclaimer: I work at Datawrapper.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/chekos/datawrapper/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/chekos/datawrapper/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
