### PR TITLE
enable strict validation for all chart model configs

### DIFF
--- a/datawrapper/charts/area.py
+++ b/datawrapper/charts/area.py
@@ -21,6 +21,9 @@ class AreaChart(BaseChart):
     model_config = ConfigDict(
         populate_by_name=True,
         strict=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
         json_schema_extra={
             "examples": [
                 {

--- a/datawrapper/charts/arrow.py
+++ b/datawrapper/charts/arrow.py
@@ -14,6 +14,9 @@ class ArrowChart(BaseChart):
     model_config = ConfigDict(
         populate_by_name=True,
         strict=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
         json_schema_extra={
             "examples": [
                 {

--- a/datawrapper/charts/bar.py
+++ b/datawrapper/charts/bar.py
@@ -81,6 +81,9 @@ class BarChart(BaseChart):
     model_config = ConfigDict(
         populate_by_name=True,
         strict=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
         json_schema_extra={
             "examples": [
                 {

--- a/datawrapper/charts/base.py
+++ b/datawrapper/charts/base.py
@@ -23,6 +23,10 @@ class BaseChart(BaseModel):
 
     model_config = ConfigDict(
         populate_by_name=True,
+        arbitrary_types_allowed=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
         json_schema_extra={
             "examples": [
                 # Example 1: A simple chart without much configuration
@@ -72,7 +76,6 @@ class BaseChart(BaseModel):
                 },
             ]
         },
-        arbitrary_types_allowed=True,  # To allow pandas DataFrame
     )
 
     #: The type of datawrapper chart to create

--- a/datawrapper/charts/column.py
+++ b/datawrapper/charts/column.py
@@ -23,6 +23,9 @@ class ColumnChart(BaseChart):
     model_config = ConfigDict(
         populate_by_name=True,
         strict=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
         json_schema_extra={
             "examples": [
                 {

--- a/datawrapper/charts/line.py
+++ b/datawrapper/charts/line.py
@@ -387,6 +387,9 @@ class LineChart(BaseChart):
     model_config = ConfigDict(
         populate_by_name=True,
         strict=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
         json_schema_extra={
             "examples": [
                 {

--- a/datawrapper/charts/multiple_column.py
+++ b/datawrapper/charts/multiple_column.py
@@ -23,6 +23,9 @@ class MultipleColumnChart(BaseChart):
     model_config = ConfigDict(
         populate_by_name=True,
         strict=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
         json_schema_extra={
             "examples": [
                 {

--- a/datawrapper/charts/scatter.py
+++ b/datawrapper/charts/scatter.py
@@ -15,6 +15,9 @@ class ScatterPlot(BaseChart):
     model_config = ConfigDict(
         populate_by_name=True,
         strict=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
         json_schema_extra={
             "examples": [
                 {

--- a/datawrapper/charts/stacked_bar.py
+++ b/datawrapper/charts/stacked_bar.py
@@ -15,6 +15,9 @@ class StackedBarChart(BaseChart):
     model_config = ConfigDict(
         populate_by_name=True,
         strict=True,
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
     )
 
     #: The type of datawrapper chart to create


### PR DESCRIPTION
Add validate_assignment, validate_default, and use_enum_values to all chart model configurations for improved data validation and type safety. Also reorganize BaseChart model_config to group validation settings together.

These Pydantic settings ensure:
- validate_assignment: validates data when attributes are modified after initialization
- validate_default: validates default values during model creation
- use_enum_values: automatically converts enum members to their values

This change strengthens runtime validation across all chart types (Area, Arrow, Bar, Column, Line, MultipleColumn, Scatter, and StackedBar) and maintains consistency with the existing strict mode configuration.