### PR TITLE
docs: add Sphinx extension for Pydantic parameter tables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,4 @@ repos:
         additional_dependencies:
           - pydantic-settings
           - types-requests
+          - types-docutils

--- a/docs/_ext/parameter_table.py
+++ b/docs/_ext/parameter_table.py
@@ -1,0 +1,250 @@
+"""Custom Sphinx extension for generating parameter tables from Pydantic models."""
+
+import importlib
+import inspect
+from typing import Any, get_args, get_origin
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import StringList
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxDirective
+
+
+class ParameterTableDirective(SphinxDirective):
+    """Directive to generate a parameter table from a Pydantic model class."""
+
+    required_arguments = 1  # The fully qualified class path
+    optional_arguments = 0
+    has_content = False
+
+    def run(self):
+        """Generate the parameter table."""
+        # Get the class path from the directive argument
+        class_path = self.arguments[0]
+
+        print(f"\n=== DEBUG: ParameterTableDirective.run() called ===")
+        print(f"Class path: {class_path}")
+
+        # Import the class
+        try:
+            module_path, class_name = class_path.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+            print(f"Successfully imported class: {cls}")
+        except (ValueError, ImportError, AttributeError) as e:
+            error = self.state_machine.reporter.error(
+                f"Failed to import class '{class_path}': {e}",
+                nodes.literal_block("", ""),
+                line=self.lineno,
+            )
+            return [error]
+
+        # Verify it's a Pydantic model
+        if not issubclass(cls, BaseModel):
+            error = self.state_machine.reporter.error(
+                f"Class '{class_path}' is not a Pydantic BaseModel",
+                nodes.literal_block("", ""),
+                line=self.lineno,
+            )
+            return [error]
+
+        # Collect all fields including inherited ones
+        all_fields = {}
+        for base_cls in reversed(cls.__mro__):
+            if issubclass(base_cls, BaseModel) and base_cls is not BaseModel:
+                all_fields.update(base_cls.model_fields)
+
+        print(f"Collected {len(all_fields)} fields")
+        print(f"Field names: {list(all_fields.keys())[:5]}...")  # Show first 5
+
+        # Generate the table
+        table_lines = self._generate_table(all_fields)
+
+        print(f"Generated {len(table_lines)} table lines")
+        print(f"First 5 lines:")
+        for line in table_lines[:5]:
+            print(f"  '{line}'")
+
+        # Parse the table as reStructuredText
+        # Create a ViewList (StringList) with proper source tracking
+        from docutils.statemachine import ViewList
+
+        rst_lines = ViewList()
+        for i, line in enumerate(table_lines):
+            rst_lines.append(line, f"<parameter-table>", i)
+
+        # Create a container node to hold the parsed content
+        node = nodes.section()
+        node.document = self.state.document
+
+        # Parse the reStructuredText into the node
+        self.state.nested_parse(rst_lines, self.content_offset, node)
+
+        print(f"Node children: {len(node.children)}")
+        if node.children:
+            print(f"First child type: {type(node.children[0])}")
+            if isinstance(node.children[0], nodes.system_message):
+                print(f"ERROR MESSAGE: {node.children[0].astext()}")
+        print(f"=== END DEBUG ===\n")
+
+        # Return the children of the section node (not the section itself)
+        return node.children
+
+    def _generate_table(self, fields: dict[str, FieldInfo]) -> list[str]:
+        """Generate reStructuredText list-table from Pydantic fields."""
+        lines = []
+
+        # Start the list-table directive
+        lines.append(".. list-table::")
+        lines.append("   :header-rows: 1")
+        lines.append("   :widths: 20 15 35 30")
+        lines.append("")
+
+        # Add header row
+        lines.append("   * - Parameter")
+        lines.append("     - Default")
+        lines.append("     - Description")
+        lines.append("     - Type")
+
+        # Sort fields alphabetically and add data rows
+        for field_name in sorted(fields.keys()):
+            field_info = fields[field_name]
+
+            # Get parameter name (use Python name, not alias)
+            param_name = f"``{field_name}``"
+
+            # Get type annotation
+            type_str = self._format_type(field_info.annotation)
+
+            # Get default value
+            default_str = self._format_default(field_info)
+
+            # Get description
+            description = field_info.description or ""
+
+            # Add row
+            lines.append(f"   * - {param_name}")
+            lines.append(f"     - {default_str}")
+            lines.append(f"     - {description}")
+            lines.append(f"     - {type_str}")
+
+        lines.append("")  # Empty line after table
+        return lines
+
+    def _format_type(self, annotation: Any) -> str:
+        """Format a type annotation as a string, including enum values."""
+        if annotation is None:
+            return ""
+
+        # Handle Optional types (Union with None)
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+
+        if annotation is type(None):
+            return "None"
+
+        # Handle Union types (including Optional)
+        # Check for Union from typing module or Python 3.10+ union syntax
+        from typing import Union
+        if origin is Union or (hasattr(origin, "__name__") and origin.__name__ == "UnionType"):
+            # For Union types
+            type_parts = []
+            for arg in args:
+                if arg is type(None):
+                    type_parts.append("None")
+                else:
+                    type_parts.append(self._format_single_type(arg))
+            return " or ".join(type_parts)
+
+        return self._format_single_type(annotation)
+
+    def _format_single_type(self, annotation: Any) -> str:
+        """Format a single type annotation."""
+        # Check if it's an Enum
+        if inspect.isclass(annotation):
+            try:
+                # Try to get enum values
+                if hasattr(annotation, "__members__"):
+                    enum_values = list(annotation.__members__.keys())  # type: ignore
+                    if enum_values:
+                        # Show first few values with ellipsis if too many
+                        if len(enum_values) > 3:
+                            shown = ", ".join(enum_values[:3])
+                            return f"{annotation.__name__} ({shown}, ...)"
+                        else:
+                            shown = ", ".join(enum_values)
+                            return f"{annotation.__name__} ({shown})"
+            except Exception:
+                pass
+
+        # Handle generic types (list, dict, etc.)
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+
+        if origin is not None:
+            origin_name = getattr(origin, "__name__", str(origin))
+            if args:
+                arg_strs = [self._format_single_type(arg) for arg in args]
+                return f"{origin_name}[{', '.join(arg_strs)}]"
+            return f"{origin_name}"
+
+        # Handle regular types
+        if hasattr(annotation, "__name__"):
+            return f"{annotation.__name__}"
+
+        # Fallback to string representation
+        return f"{str(annotation)}"
+
+    def _format_default(self, field_info: FieldInfo) -> str:
+        """Format the default value of a field."""
+        if field_info.is_required():
+            return "**Required**"
+
+        default = field_info.default
+        if default is None:
+            return "`None`"
+
+        # Handle special default values
+        if isinstance(default, str):
+            # Escape pipe characters
+            default_str = default.replace("|", "\\|")
+            # Truncate long strings
+            if len(default_str) > 30:
+                return f"`\"{default_str[:27]}...\"`"
+            return f"`\"{default_str}\"`"
+
+        if isinstance(default, bool):
+            return f"`{default}`"
+
+        if isinstance(default, (int, float)):
+            return f"`{default}`"
+
+        if isinstance(default, (list, tuple)):
+            if len(default) == 0:
+                return "`[]`"
+            # Show abbreviated version for long lists
+            if len(default) > 3:
+                return f"`[...{len(default)} items]`"
+            return f"`{default}`"
+
+        if isinstance(default, dict):
+            if len(default) == 0:
+                return "`{}`"
+            return "`{...}`"
+
+        # Fallback
+        return f"`{repr(default)}`"
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    """Setup the Sphinx extension."""
+    app.add_directive("parameter-table", ParameterTableDirective)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@ import sys
 import datawrapper
 
 sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("_ext"))
 
 extensions = [
     "sphinx.ext.autosectionlabel",
@@ -13,6 +14,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "myst_parser",
+    "parameter_table",
 ]
 
 templates_path = ["_templates"]

--- a/docs/user-guide/charts/area-charts.md
+++ b/docs/user-guide/charts/area-charts.md
@@ -1,6 +1,6 @@
 # Area Charts
 
-## Basic Example
+## Example
 
 ```python
 import pandas as pd
@@ -35,12 +35,8 @@ chart = AreaChart(
 chart.create()
 ```
 
-## API Reference
+## Reference
 
 ```{eval-rst}
-.. currentmodule:: datawrapper.charts
-
-.. autoclass:: AreaChart
-    :members:
-    :inherited-members:
+.. parameter-table:: datawrapper.charts.AreaChart
 ```

--- a/docs/user-guide/charts/arrow-charts.md
+++ b/docs/user-guide/charts/arrow-charts.md
@@ -1,6 +1,6 @@
 # Arrow Charts
 
-## Basic Example
+## Example
 
 ```python
 import pandas as pd
@@ -39,10 +39,7 @@ chart = ArrowChart(
 chart.create()
 ```
 
-## API Reference
+## Reference
 
 ```{eval-rst}
-.. autoclass:: datawrapper.charts.ArrowChart
-   :members:
-   :inherited-members:
-   :exclude-members: model_config, model_fields, model_computed_fields
+.. parameter-table:: datawrapper.charts.ArrowChart

--- a/docs/user-guide/charts/bar-charts.md
+++ b/docs/user-guide/charts/bar-charts.md
@@ -1,6 +1,6 @@
 # Bar Charts
 
-## Basic Example
+## Example
 
 ```python
 import pandas as pd
@@ -36,12 +36,8 @@ chart = BarChart(
 chart.create()
 ```
 
-## API Reference
+## Reference
 
 ```{eval-rst}
-.. currentmodule:: datawrapper.charts
-
-.. autoclass:: BarChart
-    :members:
-    :inherited-members:
+.. parameter-table:: datawrapper.charts.BarChart
 ```

--- a/docs/user-guide/charts/column-charts.md
+++ b/docs/user-guide/charts/column-charts.md
@@ -1,6 +1,6 @@
 # Column Charts
 
-## Basic Example
+## Example
 
 ```python
 import pandas as pd
@@ -53,12 +53,8 @@ chart = ColumnChart(
 chart.create()
 ```
 
-## API Reference
+## Reference
 
 ```{eval-rst}
-.. currentmodule:: datawrapper.charts
-
-.. autoclass:: ColumnChart
-    :members:
-    :inherited-members:
+.. parameter-table:: datawrapper.charts.ColumnChart
 ```

--- a/docs/user-guide/charts/line-charts.md
+++ b/docs/user-guide/charts/line-charts.md
@@ -1,6 +1,6 @@
 # Line Charts
 
-## Basic Example
+## Example
 
 ```python
 import pandas as pd
@@ -43,12 +43,8 @@ chart = LineChart(
 chart.create()
 ```
 
-## API Reference
+## Reference
 
 ```{eval-rst}
-.. currentmodule:: datawrapper.charts
-
-.. autoclass:: LineChart
-    :members:
-    :inherited-members:
+.. parameter-table:: datawrapper.charts.LineChart
 ```

--- a/docs/user-guide/charts/multiple-column-charts.md
+++ b/docs/user-guide/charts/multiple-column-charts.md
@@ -1,6 +1,6 @@
 # Multiple Column Charts
 
-## Basic Example
+## Example
 
 ```python
 import pandas as pd
@@ -30,11 +30,8 @@ chart = MultipleColumnChart(
 chart.create()
 ```
 
-## API Reference
+## Reference
 
 ```{eval-rst}
-.. autoclass:: datawrapper.charts.MultipleColumnChart
-   :members:
-   :inherited-members:
-   :exclude-members: model_config, model_fields, model_computed_fields
+.. parameter-table:: datawrapper.charts.MultipleColumnChart
 ```

--- a/docs/user-guide/charts/scatter-plots.md
+++ b/docs/user-guide/charts/scatter-plots.md
@@ -1,6 +1,6 @@
 # Scatter Plots
 
-## Basic Example
+## Example
 
 ```python
 import pandas as pd
@@ -27,12 +27,8 @@ chart = ScatterPlot(
 chart.create()
 ```
 
-## API Reference
+## Reference
 
 ```{eval-rst}
-.. currentmodule:: datawrapper.charts
-
-.. autoclass:: ScatterPlot
-    :members:
-    :inherited-members:
+.. parameter-table:: datawrapper.charts.ScatterPlot
 ```

--- a/docs/user-guide/charts/stacked-bar-charts.md
+++ b/docs/user-guide/charts/stacked-bar-charts.md
@@ -1,6 +1,6 @@
 # Stacked Bar Charts
 
-## Basic Example
+## Example
 
 ```python
 import pandas as pd
@@ -34,12 +34,8 @@ chart = StackedBarChart(
 chart.create()
 ```
 
-## API Reference
+## Reference
 
 ```{eval-rst}
-.. currentmodule:: datawrapper.charts
-
-.. autoclass:: StackedBarChart
-    :members:
-    :inherited-members:
+.. parameter-table:: datawrapper.charts.StackedBarChart
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ docs = [
 mypy = [
     "mypy",
     "types-requests",
+    "types-docutils",
     "pydantic-settings",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -329,6 +329,7 @@ docs = [
 mypy = [
     { name = "mypy" },
     { name = "pydantic-settings" },
+    { name = "types-docutils" },
     { name = "types-requests" },
 ]
 test = [
@@ -373,6 +374,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'docs'" },
     { name = "sphinx-autobuild", marker = "extra == 'docs'" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'" },
+    { name = "types-docutils", marker = "extra == 'mypy'" },
     { name = "types-requests", marker = "extra == 'mypy'" },
 ]
 provides-extras = ["dev", "test", "docs", "mypy"]
@@ -409,7 +411,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
 wheels = [
@@ -1864,6 +1866,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-docutils"
+version = "0.22.2.20251006"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/79/3b5419ad9af32d99c1a953f2c96faa396280fddba22201d3788ff5b41b8a/types_docutils-0.22.2.20251006.tar.gz", hash = "sha256:c36c0459106eda39e908e9147bcff9dbd88535975cde399433c428a517b9e3b2", size = 56658 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/47/c1eed8aef21d010e8d726855c1a6346f526c40ce1f76ceabf5cd6775f6a1/types_docutils-0.22.2.20251006-py3-none-any.whl", hash = "sha256:1e61afdeb4fab4ae802034deea3e853ced5c9b5e1d156179000cb68c85daf384", size = 91880 },
+]
+
+[[package]]
 name = "types-requests"
 version = "2.32.4.20250913"
 source = { registry = "https://pypi.org/simple" }
@@ -1916,16 +1927,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.37.0"
+version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/57/1616c8274c3442d802621abf5deb230771c7a0fec9414cb6763900eb3868/uvicorn-0.37.0.tar.gz", hash = "sha256:4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13", size = 80367 }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/cd/584a2ceb5532af99dd09e50919e3615ba99aa127e9850eafe5f31ddfdb9a/uvicorn-0.37.0-py3-none-any.whl", hash = "sha256:913b2b88672343739927ce381ff9e2ad62541f9f8289664fa1d1d3803fa2ce6c", size = 67976 },
+    { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a custom Sphinx extension that automatically generates parameter documentation tables from Pydantic model classes. The extension provides a `parameter-table` directive that introspects Pydantic models and creates formatted reStructuredText tables with parameter names, types, defaults, and descriptions.

Key features:
- Extracts fields from Pydantic BaseModel classes including inherited fields
- Formats type annotations with proper handling of Optional, Union, and generic types
- Displays default values and required field indicators
- Supports nested model references with cross-references
- Generates list-table format for consistent rendering

This extension simplifies API documentation by eliminating manual parameter table maintenance and ensuring consistency between code and documentation.