### PR TITLE
docs: fix boolean enum value rendering and update example

### DIFF
--- a/docs/_ext/enum_table.py
+++ b/docs/_ext/enum_table.py
@@ -89,6 +89,9 @@ class EnumTableDirective(SphinxDirective):
             value = member.value
             if value is None:
                 value_str = "``None``"
+            elif isinstance(value, bool):
+                # Handle boolean values (must check before int since bool is subclass of int)
+                value_str = f"``{value}``"
             elif isinstance(value, str):
                 # Escape special characters and show as string
                 escaped_value = value.replace("|", "\\|").replace("*", "\\*")

--- a/docs/user-guide/api/enums.rst
+++ b/docs/user-guide/api/enums.rst
@@ -13,7 +13,7 @@ ArrowHead
 .. code-block:: python
 
    from datawrapper.charts import ArrowHead
-   connector = ConnectorLine(arrow_head=ArrowHead.ARROW)
+   connector = ConnectorLine(arrow_head=ArrowHead.TRIANGLE)
 
 .. enum-table:: datawrapper.charts.enums.ArrowHead
 


### PR DESCRIPTION
- Add special handling for boolean enum values in enum_table directive
- Check for bool type before int since bool is a subclass of int
- Update ArrowHead example to use TRIANGLE instead of ARROW
- Ensure boolean values are properly formatted with backticks in docs

This fixes an issue where boolean enum values were not being rendered correctly in the documentation tables and updates the connector example to use a valid ArrowHead enum value.