### PR TITLE
refactor: remove redundant color_by_column field from chart classes

### DIFF
--- a/datawrapper/charts/arrow.py
+++ b/datawrapper/charts/arrow.py
@@ -173,13 +173,6 @@ class ArrowChart(BaseChart):
     # Features
     #
 
-    #: Enables the color-by-column feature
-    color_by_column: bool = Field(
-        default=False,
-        alias="color-by-column",
-        description="Enables the color-by-column feature",
-    )
-
     #: Label on the first arrow that shows column names
     arrow_key: bool = Field(
         default=False,
@@ -230,7 +223,7 @@ class ArrowChart(BaseChart):
                 "custom-range": CustomRange.serialize(self.custom_range),
                 "range-extent": self.range_extent,
                 "value-label-format": self.value_label_format,
-                "color-by-column": self.color_by_column,
+                "color-by-column": bool(self.color_category),
                 "group-by-column": self.group_by_column,
                 "replace-flags": ReplaceFlags.serialize(self.replace_flags),
                 "show-arrow-key": self.arrow_key,
@@ -328,8 +321,6 @@ class ArrowChart(BaseChart):
             init_data["label_column"] = axes["labels"]
 
         # Features
-        if "color-by-column" in visualize:
-            init_data["color_by_column"] = visualize["color-by-column"]
         if "group-by-column" in visualize:
             init_data["group_by_column"] = visualize["group-by-column"]
         if "show-arrow-key" in visualize:

--- a/datawrapper/charts/stacked_bar.py
+++ b/datawrapper/charts/stacked_bar.py
@@ -83,13 +83,6 @@ class StackedBarChart(BaseChart):
         description="The field you want to use for the value labels",
     )
 
-    #: Enables the color-by-column feature
-    color_by_column: bool = Field(
-        default=False,
-        alias="color-by-column",
-        description="Enables the color-by-column feature",
-    )
-
     #: Enables the legend
     show_color_key: bool = Field(
         default=False,
@@ -196,7 +189,7 @@ class StackedBarChart(BaseChart):
                 "show-color-key": self.show_color_key,
                 "value-label-format": self.value_label_format,
                 "date-label-format": self.date_label_format,
-                "color-by-column": self.color_by_column,
+                "color-by-column": bool(self.color_category),
                 "group-by-column": self.groups_column is not None,
                 "thick": self.thick_bars,
                 "replace-flags": ReplaceFlags.serialize(self.replace_flags),
@@ -252,8 +245,6 @@ class StackedBarChart(BaseChart):
             init_data["value_label_format"] = visualize["value-label-format"]
         if "date-label-format" in visualize:
             init_data["date_label_format"] = visualize["date-label-format"]
-        if "color-by-column" in visualize:
-            init_data["color_by_column"] = visualize["color-by-column"]
         if "thick" in visualize:
             init_data["thick_bars"] = visualize["thick"]
 

--- a/tests/integration/test_arrow_chart.py
+++ b/tests/integration/test_arrow_chart.py
@@ -210,14 +210,12 @@ class TestArrowChartCreation:
             data=pd.DataFrame({"x": [1, 2], "y": [10, 20], "z": [15, 25]}),
             start_column="y",
             end_column="z",
-            color_by_column=True,
             group_by_column=True,
             arrow_key=True,
         )
 
         serialized = chart.serialize_model()
 
-        assert serialized["metadata"]["visualize"]["color-by-column"] is True
         assert serialized["metadata"]["visualize"]["group-by-column"] is True
         assert serialized["metadata"]["visualize"]["show-arrow-key"] is True
 
@@ -291,7 +289,6 @@ class TestArrowChartGet:
             # Verify features
             assert chart.thick_arrows is True
             assert chart.arrow_key is True
-            assert chart.color_by_column is True
             assert chart.group_by_column is True
 
             # Verify sorting

--- a/tests/integration/test_stacked_bar_chart.py
+++ b/tests/integration/test_stacked_bar_chart.py
@@ -271,7 +271,6 @@ class TestStackedBarChartParsing:
             assert chart.sort_by == "I like them a lot"
             assert chart.base_color == 2
             assert chart.show_color_key is True
-            assert chart.color_by_column is True
             assert chart.value_label_format == "0%"
             assert len(chart.color_category) > 0
             assert "I like them a lot" in chart.color_category
@@ -305,7 +304,6 @@ class TestStackedBarChartParsing:
             assert chart.sort_by == "share of people in capital"
             assert chart.base_color == 0
             assert chart.show_color_key is True
-            assert chart.color_by_column is True
             assert chart.negative_color is None
 
     def test_parse_media_trust_sample(self):
@@ -341,7 +339,6 @@ class TestStackedBarChartParsing:
             assert chart.value_label_mode == "diverging"
             assert chart.block_labels is True
             assert chart.show_color_key is True
-            assert chart.color_by_column is True
 
     def test_parse_sugar_sample(self):
         """Test parsing the sugar.json sample."""
@@ -374,7 +371,6 @@ class TestStackedBarChartParsing:
             assert chart.sort_by == "Sucrose (Fructose+Glucose)"
             assert chart.base_color == 0
             assert chart.show_color_key is True
-            assert chart.color_by_column is True
             assert chart.groups_column == "Description"  # From axes.groups
             assert chart.value_label_format == "0.[0]"
 
@@ -580,7 +576,6 @@ class TestStackedBarChartCompatibility:
         assert hasattr(chart, "source_url")
         assert hasattr(chart, "aria_description")
         assert hasattr(chart, "range_value_labels")
-        assert hasattr(chart, "color_by_column")
         assert hasattr(chart, "groups_column")
         assert hasattr(chart, "show_color_key")
         assert hasattr(chart, "value_label_mode")
@@ -604,7 +599,6 @@ class TestStackedBarChartCompatibility:
         assert chart.source_url == ""
         assert chart.aria_description == ""
         assert chart.range_value_labels == ""
-        assert chart.color_by_column is False
         assert chart.groups_column is None
         assert chart.show_color_key is False
         assert chart.value_label_mode == "left"


### PR DESCRIPTION
Remove the explicit `color_by_column` boolean field from ArrowChart and StackedBarChart classes. The color-by-column feature is now automatically derived from the presence of `color_category` data instead of being a separate configuration flag.

This simplifies the API by eliminating redundant state - if `color_category` is set, color-by-column is enabled; otherwise it's disabled. Updated serialization logic to use `bool(self.color_category)` and removed corresponding deserialization and test code.

Fixes #465