### PR TITLE
feat(charts): add x-axis column configuration for line charts

### DIFF
--- a/datawrapper/charts/line.py
+++ b/datawrapper/charts/line.py
@@ -576,6 +576,13 @@ class LineChart(
         description="The type of datawrapper chart to create",
     )
 
+    #: The column to use for the x-axis
+    x_column: str | None = Field(
+        default=None,
+        alias="x-column",
+        description="The column to use for the x-axis",
+    )
+
     #
     # Horizontal axis (X-axis)
     #
@@ -777,6 +784,10 @@ class LineChart(
         # Call the parent class's serialize_model method
         model = super().serialize_model()
 
+        # Set the axes setting if x_column is provided
+        if self.x_column:
+            model["metadata"]["axes"] = {"x": self.x_column}
+
         # Add chart specific properties
         visualize_data = {
             # Horizontal axis (from mixins)
@@ -852,6 +863,11 @@ class LineChart(
         # Extract line-specific sections
         metadata = api_response.get("metadata", {})
         visualize = metadata.get("visualize", {})
+
+        # Parse axes columns
+        axes = metadata.get("axes", {})
+        if "x" in axes:
+            init_data["x_column"] = axes["x"]
 
         # Horizontal and vertical axis (from mixins)
         init_data.update(cls._deserialize_grid_config(visualize))


### PR DESCRIPTION
Add support for specifying the x-axis column in line charts through a new `x_column` field. This allows users to explicitly set which data column should be used for the x-axis.

Changes:
- Add `x_column` field to LineChart model with alias "x-column"
- Serialize x_column to metadata.axes.x when creating/updating charts
- Deserialize axes.x back to x_column when loading existing charts
- Include field documentation and type hints (str | None)

This enhancement provides more control over chart axis configuration and maintains consistency with Datawrapper's API structure.