### PR TITLE
refactor(bar): rename 'thick' field to 'thick_bars' for clarity

### DIFF
--- a/datawrapper/charts/bar.py
+++ b/datawrapper/charts/bar.py
@@ -315,7 +315,7 @@ class BarChart(AnnotationsMixin, BaseChart):
     )
 
     #: Make the bars thicker
-    thick: bool = Field(
+    thick_bars: bool = Field(
         default=False, alias="thick", description="Make the bars thicker"
     )
 
@@ -432,7 +432,7 @@ class BarChart(AnnotationsMixin, BaseChart):
                 ),
                 "color-by-column": bool(self.color_category),
                 "rules": self.rules,
-                "thick": self.thick,
+                "thick": self.thick_bars,
                 "background": self.background,
                 # Sorting and grouping
                 "sort-bars": self.sort_bars,
@@ -563,7 +563,7 @@ class BarChart(AnnotationsMixin, BaseChart):
         if "rules" in visualize:
             init_data["rules"] = visualize["rules"]
         if "thick" in visualize:
-            init_data["thick"] = visualize["thick"]
+            init_data["thick_bars"] = visualize["thick"]
         if "background" in visualize:
             init_data["background"] = visualize["background"]
 

--- a/tests/functional/test_end_to_end.py
+++ b/tests/functional/test_end_to_end.py
@@ -158,7 +158,7 @@ class TestEndToEndWorkflows:
             bar_column="values",
             base_color="#4682B4",
             background=True,
-            thick=True,
+            thick_bars=True,
         )
 
         # Step 2: Apply advanced customizations
@@ -180,7 +180,7 @@ class TestEndToEndWorkflows:
         # Step 4: Verify customizations are applied
         assert chart.base_color == "#4682B4"
         assert chart.background is True
-        assert chart.thick is True
+        assert chart.thick_bars is True
         assert chart.sort_bars is True
         assert chart.reverse_order is True
         assert chart.custom_range == (0, 100)
@@ -324,7 +324,7 @@ class TestEndToEndWorkflows:
                 bar_column="values",
                 base_color="#FF6B6B",
                 background=True,
-                thick=True,
+                thick_bars=True,
             ),
         }
 

--- a/tests/integration/test_chart_get_method.py
+++ b/tests/integration/test_chart_get_method.py
@@ -302,7 +302,7 @@ class TestBarChartGet:
             assert chart.reverse_order is True
             assert chart.background is True
             assert chart.rules is True
-            assert chart.thick is False
+            assert chart.thick_bars is False
             assert chart.tick_position == "top"
 
             # Verify custom range


### PR DESCRIPTION
Renamed the `thick` field to `thick_bars` in the BarChart class to improve code readability and make the field name more descriptive. The field still uses "thick" as an alias to maintain backward compatibility with the API.

Changes:
- Renamed field from `thick` to `thick_bars` in BarChart model
- Updated all references in serialization and deserialization methods
- Updated test assertions to use new field name

This change makes the codebase more maintainable by using a more explicit field name while preserving the existing API contract through aliasing.