### PR TITLE
feat(charts): add highlighted series support to column charts

### DIFF
--- a/datawrapper/charts/column.py
+++ b/datawrapper/charts/column.py
@@ -194,6 +194,17 @@ class ColumnChart(
         description="Where to place the value labels",
     )
 
+    #
+    # Annotations
+    #
+
+    #: A list of the highlighted series
+    highlighted_series: list[str] = Field(
+        default_factory=list,
+        alias="highlighted-series",
+        description="A list of the highlighted series",
+    )
+
     @field_validator("plot_height_mode")
     @classmethod
     def validate_plot_height_mode(cls, v: PlotHeightMode | str) -> PlotHeightMode | str:
@@ -354,6 +365,8 @@ class ColumnChart(
                 placement=self.value_labels_placement,
                 chart_type="column",
             ),
+            # Annotations
+            "highlighted-series": self.highlighted_series,
         }
 
         model["metadata"]["visualize"].update(visualize_data)
@@ -424,5 +437,7 @@ class ColumnChart(
 
         # Annotations
         init_data.update(cls._deserialize_annotations(visualize))
+        if "highlighted-series" in visualize:
+            init_data["highlighted_series"] = visualize["highlighted-series"]
 
         return init_data


### PR DESCRIPTION
Add highlighted_series field to ColumnChart for annotation purposes,
allowing users to specify which series should be visually emphasized.

Changes:
- Add highlighted_series field with alias "highlighted-series"
- Include field in serialization output under Annotations section
- Handle deserialization of highlighted-series from visualize metadata