### PR TITLE
Fix Windows UTF-8 decoding issues in sample JSON tests

### DIFF
--- a/tests/integration/test_area_chart.py
+++ b/tests/integration/test_area_chart.py
@@ -13,14 +13,14 @@ from datawrapper import AreaChart
 def load_sample_json(filename: str) -> dict:
     """Load a sample JSON file from tests/samples/area directory."""
     samples_dir = Path(__file__).parent.parent / "samples" / "area"
-    with open(samples_dir / filename) as f:
+    with open(samples_dir / filename, encoding="utf-8") as f:
         return json.load(f)
 
 
 def load_sample_csv(filename: str) -> str:
     """Load a sample CSV file from tests/samples/area directory."""
     samples_dir = Path(__file__).parent.parent / "samples" / "area"
-    with open(samples_dir / filename) as f:
+    with open(samples_dir / filename, encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/integration/test_area_chart.py
+++ b/tests/integration/test_area_chart.py
@@ -163,6 +163,23 @@ class TestAreaChartCreation:
 class TestAreaChartGet:
     """Tests for AreaChart.get() method."""
 
+    def test_tate_fixture_loads_with_explicit_utf8_encoding(self):
+        """Regression test for Windows cp1252 fixture-decoding failures."""
+        with patch("builtins.open", wraps=open) as mocked_open:
+            sample_json = load_sample_json("tate.json")
+
+        chart_metadata = sample_json["chart"]["crdt"]["data"]
+
+        assert mocked_open.call_args.kwargs["encoding"] == "utf-8"
+        assert chart_metadata["title"] == (
+            "Only 4% of all artworks acquired by Tate were created by women"
+        )
+        annotation_text = chart_metadata["metadata"]["visualize"]["text-annotations"][
+            "mobwnf7rs6"
+        ]["text"]
+
+        assert "←" in annotation_text
+
     def test_get_migration_sample(self):
         """Test get() with migration.json sample data (complex stacked chart)."""
         # Load sample data

--- a/tests/integration/test_scatter_chart.py
+++ b/tests/integration/test_scatter_chart.py
@@ -13,7 +13,7 @@ from datawrapper.charts import ScatterPlot
 def load_sample_json(filename: str) -> dict:
     """Load a sample JSON file from tests/samples/scatter/."""
     path = Path(__file__).parent.parent / "samples" / "scatter" / filename
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         data = json.load(f)
         return data["chart"]["crdt"]["data"]
 
@@ -22,7 +22,7 @@ def load_sample_csv(filename: str) -> str:
     """Load a sample CSV file from tests/samples/scatter/."""
     path = Path(__file__).parent.parent / "samples" / "scatter" / filename
     # Read the file and convert tabs to commas if needed
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         content = f.read()
         # Check if this is a tab-delimited file
         if "\t" in content.split("\n")[0]:

--- a/tests/integration/test_scatter_chart.py
+++ b/tests/integration/test_scatter_chart.py
@@ -469,6 +469,21 @@ class TestScatterPlotSerialization:
 class TestScatterPlotParsing:
     """Test parsing ScatterPlot from API responses."""
 
+    def test_automation_fixture_loads_with_explicit_utf8_encoding(self):
+        """Regression test for Windows cp1252 fixture-decoding failures."""
+        with patch("builtins.open", wraps=open) as mocked_open:
+            chart_metadata = load_sample_json("automation.json")
+            sample_csv = load_sample_csv("automation.csv")
+
+        encoding_kwargs = [call.kwargs["encoding"] for call in mocked_open.call_args_list]
+
+        assert encoding_kwargs == ["utf-8", "utf-8"]
+        assert chart_metadata["title"] == (
+            "Higher Risk of Job Automation in Lower Paying Jobs"
+        )
+        assert "Helpers–Brickmasons" in sample_csv
+        assert "Helpersâ€“Brickmasons" not in sample_csv
+
     def test_parse_automation_sample(self):
         """Test parsing the automation sample JSON."""
         chart_metadata = load_sample_json("automation.json")


### PR DESCRIPTION
When running tests on a Windows machine the scatter chart and area chart tests fail when attempting to load sample json, due to encoding issues.
Specifying encoding as utf-8 fixes the problem.  

Example fail
`======================================================================== FAILURES ========================================================================= __________________________________________________________ TestAreaChartGet.test_get_tate_sample __________________________________________________________ tests\integration\test_area_chart.py:268: in test_get_tate_sample sample_json = load_sample_json("tate.json") ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ tests\integration\test_area_chart.py:17: in load_sample_json return json.load(f) ^^^^^^^^^^^^ C:\Python313\Lib\json_init_.py:293: in load return loads(fp.read(), ^^^^^^^^^ C:\Python313\Lib\encodings\cp1252.py:23: in decode return codecs.charmap_decode(input,self.errors,decoding_table)[0] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E   UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 9330: character maps to <undefined> ================================================================= short test summary info =================================================================
FAILED tests/integration/test_area_chart.py::TestAreaChartGet::test_get_tate_sample - UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 9330: character maps to <undefined> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================= 1 failed, 177 passed in 20.54s ==============================================================
`