### PR TITLE
fix(area): emit categoryLabels to override theme default

### DIFF
--- a/datawrapper/charts/area.py
+++ b/datawrapper/charts/area.py
@@ -261,6 +261,7 @@ class AreaChart(
             "color-category": ColorCategory.serialize(self.color_category),
             # Labels
             "show-color-key": self.show_color_key,
+            "categoryLabels": {"enabled": self.show_color_key, "position": "color-key"},
             # Tooltips
             "show-tooltips": self.show_tooltips,
             "tooltip-x-format": self.tooltip_x_format,

--- a/tests/integration/test_area_chart.py
+++ b/tests/integration/test_area_chart.py
@@ -108,6 +108,26 @@ class TestAreaChartCreation:
             "Series B": "#0000ff",
         }
         assert serialized["metadata"]["visualize"]["show-color-key"] is True
+        assert serialized["metadata"]["visualize"]["categoryLabels"] == {
+            "enabled": True,
+            "position": "color-key",
+        }
+
+    def test_serialize_show_color_key_false(self):
+        """Test that show_color_key=False also disables categoryLabels."""
+        chart = AreaChart(
+            title="Test",
+            data=pd.DataFrame({"x": [1, 2], "y": [10, 20]}),
+            show_color_key=False,
+        )
+
+        serialized = chart.serialize_model()
+
+        assert serialized["metadata"]["visualize"]["show-color-key"] is False
+        assert serialized["metadata"]["visualize"]["categoryLabels"] == {
+            "enabled": False,
+            "position": "color-key",
+        }
 
     def test_serialize_with_tooltips(self):
         """Test serializing with tooltip configuration."""


### PR DESCRIPTION
## Summary

- When `show_color_key=False` is set on `AreaChart`, the Datawrapper API correctly receives `"show-color-key": false`, but the color key still renders because the Reuters theme (`thomson-reuters--redesign`) sets a separate visualize-level default: `categoryLabels: {enabled: true, position: "color-key"}`
- This adds `categoryLabels` to the serialized output, synced with `show_color_key`, so the explicit setting actually takes effect visually
- Adds tests for both `show_color_key=True` and `show_color_key=False` verifying `categoryLabels` is emitted correctly

## Test plan

- [x] `pytest tests/integration/test_area_chart.py -v` — 14 passed
- [x] `pytest tests/ -v` — 1072 passed, 0 failures
- [ ] Create a test chart with the Reuters theme and `show_color_key=False`, verify the color key no longer renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)