### PR TITLE
chore: harden AI agent workflow

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -5,31 +5,38 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  DATAWRAPPER_ACCESS_TOKEN: ${{ secrets.DATAWRAPPER_ACCESS_TOKEN }}
-
 jobs:
   lint-python:
-    name: Lint Python code
+    name: Lint and format Python code
     runs-on: ubuntu-latest
     steps:
       - id: checkout
         name: Checkout
         uses: actions/checkout@v7
 
+      - id: install-uv
+        name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: '**/uv.lock'
+
+      - id: install-python
+        name: Install Python
+        run: uv python install 3.13
+
+      - id: install-python-dependencies
+        name: Install Python dependencies
+        run: uv sync --frozen --extra dev --extra test
+
       - id: check-ruff
         name: Check with Ruff
-        uses: astral-sh/ruff-action@v4.1.0
-        with:
-          args: 'check --exit-zero --verbose'
-          src: './datawrapper'
+        run: uv run ruff check ./datawrapper ./tests
 
       - id: format-ruff
-        name: Format with Ruff
-        uses: astral-sh/ruff-action@v4.1.0
-        with:
-          args: 'format --check --verbose'
-          src: './datawrapper'
+        name: Check formatting with Ruff
+        run: uv run ruff format --check ./datawrapper ./tests
 
   mypy-python:
     name: Check Python static typing
@@ -45,7 +52,7 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
+          cache-dependency-glob: '**/uv.lock'
 
       - id: install-python
         name: Install Python
@@ -53,11 +60,11 @@ jobs:
 
       - id: install-python-dependencies
         name: Install Python dependencies
-        run: uv sync --extra mypy
+        run: uv sync --frozen --extra mypy
 
       - id: mypy
         name: Run mypy
-        run: uv run mypy ./ --ignore-missing-imports
+        run: uv run mypy ./datawrapper --ignore-missing-imports
 
   test-python:
     name: Test Python code
@@ -75,7 +82,7 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
+          cache-dependency-glob: '**/uv.lock'
 
       - id: install-python
         name: Install Python
@@ -83,18 +90,18 @@ jobs:
 
       - id: install-python-dependencies
         name: Install Python dependencies
-        run: uv sync --extra test --python ${{ matrix.python }}
+        run: uv sync --frozen --extra test --python ${{ matrix.python }}
         shell: bash
 
       - id: tests
         name: Run tests
-        run: uv run pytest --cov -sv
+        run: uv run pytest
         shell: bash
 
   build:
     name: Build release candidate
     runs-on: ubuntu-latest
-    needs: [test-python]
+    needs: [lint-python, mypy-python, test-python]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -105,7 +112,7 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
+          cache-dependency-glob: '**/uv.lock'
 
       - id: install-python
         name: Install Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
         args:
-          - '--maxkb=100000'
+          - '--maxkb=1024'
       - id: fix-byte-order-marker
       - id: check-case-conflict
       - id: check-json
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - '--py37-plus'
+          - '--py310-plus'
 
   - repo: 'https://github.com/pre-commit/mirrors-mypy'
     rev: v2.3.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent guide for Datawrapper
+
+This repository is friendly to AI-assisted edits, but agents should stay inside the same guardrails as human contributors.
+
+## Start here
+
+1. Read `README.md`, `CONTRIBUTING.md`, and this file before changing code.
+2. Work from the latest `main` branch unless the maintainer tells you otherwise.
+3. Keep pull requests focused. Do not mix dependency upgrades, broad refactors, generated artifacts, and product changes in one PR.
+4. Prefer the object-oriented chart API (`BarChart`, `LineChart`, `get_chart`, etc.) for new work. Treat lower-level `Datawrapper` methods as legacy compatibility paths unless a task explicitly targets them.
+
+## Canonical local commands
+
+Install the locked dependencies:
+
+```bash
+uv sync --frozen --all-extras
+```
+
+Run the same deterministic checks expected before a PR:
+
+```bash
+uv run ruff check ./datawrapper ./tests
+uv run ruff format --check ./datawrapper ./tests
+uv run mypy ./datawrapper --ignore-missing-imports
+uv run pytest
+uv build --sdist --wheel
+```
+
+Before committing, run the hook suite against all files:
+
+```bash
+uv run pre-commit run --all-files
+```
+
+## Test strategy
+
+- Put fast, isolated validation in `tests/unit/`.
+- Put mocked multi-component behavior in `tests/integration/` or `tests/functional/`.
+- Mark tests that require the real Datawrapper API with `@pytest.mark.api` and a `DATAWRAPPER_ACCESS_TOKEN` skip guard. The default local and CI test runs must pass without credentials.
+- Prefer `responses`, `pytest-mock`, or `unittest.mock` over live HTTP calls for regression tests.
+- When fixing a bug, add a regression test that would fail before the fix.
+
+## Change boundaries
+
+- Do not commit `.venv/`, `.ruff_cache/`, `.mypy_cache/`, `htmlcov/`, `coverage.xml`, `dist/`, or other generated outputs.
+- Do not edit `uv.lock` or dependency constraints unless the task is explicitly about dependency maintenance.
+- Do not add secrets, API tokens, recordings of API responses containing private data, or maintainer-specific local configuration.
+- Do not publish releases, merge pull requests, or change repository settings.
+
+## AI-specific safety checks
+
+Agents commonly make mistakes in this codebase by using stale legacy examples, weakening CI to make failures disappear, or adding broad generated documentation. Avoid those shortcuts. If a check is too slow or flaky, document the evidence in the PR and choose the strongest practical alternative instead of disabling it silently.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,69 @@
 # How to contribute
 
+Thanks for helping improve `datawrapper`. Please keep changes focused and easy to review.
+
 ## Dependencies
 
-Clone the repository. Move into the directory on your terminal.
+Clone the repository and move into it on your terminal.
 
-Install dependencies for development.
+Install the locked development dependencies with `uv`:
 
 ```sh
-uv sync
+uv sync --frozen --all-extras
 ```
 
-Install pre-commit to run a battery of automatic quick fixes against your work.
+Use `--frozen` for normal development and CI parity. It verifies the existing `uv.lock` instead of refreshing dependency versions.
+
+Install pre-commit to run quick local guardrails before each commit:
 
 ```sh
 uv run pre-commit install
 ```
 
-### Tests
+You can also run the full hook suite manually:
 
-You can run unit tests to verify the library is working with the following:
-
-```bash
-uv run pytest --cov -sv
+```sh
+uv run pre-commit run --all-files
 ```
 
-We also enforce ruff for linting, handled primarily via pre-commit. You can run it manually like so:
+## Tests and checks
+
+Run the full local validation suite before opening a pull request:
 
 ```bash
-uv run ruff check ./datawrapper
-```
-
-We also enforce static typing with mypy, also handled via pre-commit. You can run it manually like so:
-
-```bash
+uv run ruff check ./datawrapper ./tests
+uv run ruff format --check ./datawrapper ./tests
 uv run mypy ./datawrapper --ignore-missing-imports
+uv run pytest
+uv build --sdist --wheel
 ```
 
-### Before submitting
+For quicker iteration, run targeted tests first, then finish with the full suite:
+
+```bash
+uv run pytest tests/unit/test_flags.py
+uv run pytest tests/functional/test_chart_factory.py -k unsupported
+```
+
+## Test strategy
+
+- Add or update tests for behavior changes and bug fixes.
+- Keep the default test suite deterministic and credential-free. Tests that call the live Datawrapper API must be marked `@pytest.mark.api` and skipped unless `DATAWRAPPER_ACCESS_TOKEN` is set.
+- Prefer mocked HTTP tests with `responses`, `pytest-mock`, or `unittest.mock` for regression coverage.
+- Put fast isolated tests in `tests/unit/`, mocked multi-component tests in `tests/integration/` or `tests/functional/`, and real API smoke tests behind the `api` marker.
+
+## Before submitting
 
 Before submitting your code please do the following steps:
 
-1. Add any changes you want
-1. Add tests for the new changes
-1. Run tests
-1. Run the pre-commit hooks
-1. Edit documentation if you have changed something significant
+1. Keep the change scoped to one purpose.
+2. Add tests for the new or changed behavior.
+3. Update documentation when user-facing behavior, setup, or commands change.
+4. Run the full validation suite listed above.
+5. Confirm you did not commit generated artifacts such as `.venv/`, `.ruff_cache/`, `.mypy_cache/`, `htmlcov/`, `coverage.xml`, or `dist/`.
+
+## Guidance for AI agents
+
+AI-assisted pull requests are welcome when they follow the same contribution rules. Agents should also read `AGENTS.md` before editing. Do not weaken linting, type checks, tests, or CI to hide failures; if a check is impractical, explain the evidence and choose the strongest practical alternative.
 
 Now you're ready to submit your pull request.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ import datawrapper as dw
 # Configure a bar chart
 chart = dw.BarChart(
     title="Top Programming Languages 2024",
-    data=pd.DataFrame({"Language": ["Python", "JavaScript", "Java"], "Users": [45.3, 38.2, 30.5]}),
-    axis_label_format=dw.NumberFormat.ONE_DECIMAL
+    data=pd.DataFrame(
+        {"Language": ["Python", "JavaScript", "Java"], "Users": [45.3, 38.2, 30.5]}
+    ),
+    axis_label_format=dw.NumberFormat.ONE_DECIMAL,
 )
 
 # Create and publish (uses DATAWRAPPER_ACCESS_TOKEN environment variable)
@@ -43,12 +45,10 @@ See the [full documentation](https://datawrapper.readthedocs.io/) for comprehens
 
 ### Contributing
 
-Clone the repository. Move into the directory on your terminal.
-
-Install dependencies for development.
+Clone the repository and install the locked development dependencies.
 
 ```bash
-uv install --all-extras
+uv sync --frozen --all-extras
 ```
 
 Install pre-commit to run a battery of automatic quick fixes against your work.
@@ -57,11 +57,17 @@ Install pre-commit to run a battery of automatic quick fixes against your work.
 uv run pre-commit install
 ```
 
-Run tests with
+Run the canonical local checks before opening a pull request.
 
 ```bash
+uv run ruff check ./datawrapper ./tests
+uv run ruff format --check ./datawrapper ./tests
+uv run mypy ./datawrapper --ignore-missing-imports
 uv run pytest
+uv build --sdist --wheel
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. AI agents should also read [AGENTS.md](AGENTS.md) before changing files.
 
 ## 📈 Releases
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,8 @@ Maintainer = "https://github.com/chekos/"
 Source = "https://github.com/chekos/datawrapper"
 Issues = "https://github.com/chekos/datawrapper/issues/"
 
-[tool.setuptools]
-packages = ["datawrapper"]
+[tool.setuptools.packages.find]
+include = ["datawrapper*"]
 
 [tool.setuptools.package-data]
 datawrapper = ["py.typed"]

--- a/tests/functional/test_public_api_guardrails.py
+++ b/tests/functional/test_public_api_guardrails.py
@@ -1,0 +1,79 @@
+"""Guardrail tests for public API paths agents commonly modify."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datawrapper import BarChart, Datawrapper, get_chart
+
+
+@pytest.mark.parametrize(
+    ("metadata_type", "expected_error"),
+    [
+        (None, "has no type field in metadata"),
+        ("", "has no type field in metadata"),
+        ("unknown-chart-type", "Unsupported chart type: unknown-chart-type"),
+    ],
+)
+def test_get_chart_rejects_missing_or_unsupported_chart_types(
+    clean_env, metadata_type, expected_error
+):
+    """The typed chart factory must fail clearly instead of guessing a class."""
+    mock_client = MagicMock(spec=Datawrapper)
+    mock_client.get_chart.return_value = {
+        "id": "chart-123",
+        "title": "Unknown chart",
+        "type": metadata_type,
+        "metadata": {"visualize": {}},
+    }
+
+    with patch("datawrapper.Datawrapper", return_value=mock_client):
+        with pytest.raises(ValueError, match=expected_error):
+            get_chart("chart-123")
+
+    mock_client.get_chart.assert_called_once_with("chart-123")
+
+
+def test_get_chart_prefers_explicit_token_over_environment(env_with_token):
+    """Explicit credentials should win over ambient environment state."""
+    mock_client = MagicMock(spec=Datawrapper)
+    mock_client.get_chart.return_value = {
+        "id": "bar-123",
+        "title": "Explicit token chart",
+        "type": "d3-bars",
+        "metadata": {"visualize": {}},
+    }
+
+    with (
+        patch("datawrapper.Datawrapper", return_value=mock_client) as mock_dw_class,
+        patch.object(
+            BarChart, "get", return_value=BarChart(title="Explicit token chart")
+        ) as mock_get,
+    ):
+        get_chart("bar-123", access_token="explicit-token")
+
+    mock_dw_class.assert_called_once_with(access_token="explicit-token")
+    mock_get.assert_called_once_with(chart_id="bar-123", access_token="explicit-token")
+
+
+def test_get_chart_converts_empty_environment_token_to_none(monkeypatch):
+    """An empty DATAWRAPPER_ACCESS_TOKEN should not be passed as a real token."""
+    monkeypatch.setenv("DATAWRAPPER_ACCESS_TOKEN", "")
+    mock_client = MagicMock(spec=Datawrapper)
+    mock_client.get_chart.return_value = {
+        "id": "bar-456",
+        "title": "Empty token chart",
+        "type": "d3-bars",
+        "metadata": {"visualize": {}},
+    }
+
+    with (
+        patch("datawrapper.Datawrapper", return_value=mock_client) as mock_dw_class,
+        patch.object(
+            BarChart, "get", return_value=BarChart(title="Empty token chart")
+        ) as mock_get,
+    ):
+        get_chart("bar-456")
+
+    mock_dw_class.assert_called_once_with(access_token=None)
+    mock_get.assert_called_once_with(chart_id="bar-456", access_token=None)


### PR DESCRIPTION
## Summary

This PR hardens the repository so both human contributors and AI agents have a clearer, safer path to make changes correctly.

### Guardrails added

- Added `AGENTS.md` with agent-facing setup, canonical checks, test strategy, and change boundaries.
- Expanded `CONTRIBUTING.md` and `README.md` with lockfile-respecting setup and PR verification commands.
- Tightened pre-commit hooks:
  - lowered `check-added-large-files` from 100 MB to 1 MB to catch generated artifacts earlier;
  - aligned `pyupgrade` with the project’s `requires-python >=3.10`.
- Strengthened CI:
  - removed Ruff `--exit-zero`, so lint failures now fail CI;
  - checks both `datawrapper` and `tests` formatting/linting;
  - uses `uv sync --frozen` and caches from `uv.lock`;
  - scopes mypy to `./datawrapper` to match contributor docs;
  - requires lint, type checks, and tests before building the release candidate;
  - avoids exposing `DATAWRAPPER_ACCESS_TOKEN` as a workflow-wide env var.
- Switched setuptools package configuration to `find` all `datawrapper*` packages so the build check protects chart subpackages instead of warning that they may be omitted.
- Added mocked regression/guardrail tests for `get_chart()` covering unsupported/missing chart types and explicit-vs-environment token behavior.

## Validation

Ran locally from a fresh task worktree on Python 3.13.14:

```bash
uv sync --frozen --all-extras
uv run ruff check ./datawrapper ./tests
uv run ruff format --check ./datawrapper ./tests
uv run mypy ./datawrapper --ignore-missing-imports
uv run pytest
uv build --sdist --wheel
uv run pre-commit run --all-files
```

Results:

- `ruff check`: passed
- `ruff format --check`: passed (`140 files already formatted`)
- `mypy`: passed (`Success: no issues found in 47 source files`)
- `pytest`: passed (`1077 passed, 3 skipped`)
- `uv build --sdist --wheel`: passed and produced sdist/wheel
- `pre-commit run --all-files`: passed all hooks

## Remaining gaps / notes

- `uv build` still emits existing setuptools deprecation warnings about `project.license` and license classifiers. I did not change those here because this PR is focused on workflow hardening, not packaging metadata modernization.
- Live Datawrapper API tests remain credential-gated by `DATAWRAPPER_ACCESS_TOKEN`; the default local/CI path remains deterministic and credential-free.

## AI agent workflow

Agents should read `AGENTS.md`, install with `uv sync --frozen --all-extras`, keep changes focused, add mocked regression tests for behavior changes, and run the documented local validation suite before opening a PR. Agents should not weaken CI/checks to hide failures; if a check is impractical, the PR should document why and choose the strongest practical alternative.
