### PR TITLE
Improve BaseChart string representation

### DIFF
--- a/datawrapper/charts/base.py
+++ b/datawrapper/charts/base.py
@@ -498,6 +498,21 @@ class BaseChart(BaseModel):
         super().__init__(**data)
         self._client = None
 
+    def __str__(self) -> str:
+        """Return a compact, safe summary of the chart.
+
+        Pydantic's default string representation includes every model field, which can
+        be noisy for chart objects and may expose the chart's underlying data or custom
+        metadata. Keep the public string form focused on stable identifying details.
+        """
+        return (
+            f"{self.__class__.__name__}("
+            f"title={self.title!r}, "
+            f"chart_type={self.chart_type!r}, "
+            f"chart_id={self.chart_id!r}"
+            ")"
+        )
+
     def _get_client(self, access_token: str | None = None) -> Datawrapper:
         """Get or create a Datawrapper client instance.
 

--- a/tests/unit/test_base_chart_str.py
+++ b/tests/unit/test_base_chart_str.py
@@ -1,0 +1,50 @@
+"""Tests for the safe string representation of chart objects."""
+
+import pandas as pd
+
+import datawrapper
+
+
+def test_base_chart_str_is_compact_and_identifying():
+    chart = datawrapper.BaseChart.model_validate(
+        {
+            "chart-type": "d3-lines",
+            "title": "Monthly revenue",
+        }
+    )
+    chart.chart_id = "abc123"
+
+    assert str(chart) == (
+        "BaseChart(title='Monthly revenue', chart_type='d3-lines', chart_id='abc123')"
+    )
+
+
+def test_base_chart_str_omits_data_and_custom_metadata():
+    chart = datawrapper.BarChart(
+        title="Sensitive chart",
+        data=pd.DataFrame(
+            {
+                "api_token": ["do-not-leak"],
+                "value": [1],
+            }
+        ),
+        custom={"internal_payload": {"secret": "also-do-not-leak"}},
+    )
+
+    rendered = str(chart)
+
+    assert rendered == (
+        "BarChart(title='Sensitive chart', chart_type='d3-bars', chart_id=None)"
+    )
+    assert "api_token" not in rendered
+    assert "do-not-leak" not in rendered
+    assert "internal_payload" not in rendered
+    assert "also-do-not-leak" not in rendered
+
+
+def test_base_chart_str_uses_subclass_name_and_type():
+    chart = datawrapper.LineChart(title="Trend over time")
+
+    assert str(chart) == (
+        "LineChart(title='Trend over time', chart_type='d3-lines', chart_id=None)"
+    )


### PR DESCRIPTION
## Summary
- Add a compact `BaseChart.__str__` implementation with stable identifying details: class name, title, chart type and chart ID.
- Avoid dumping chart data, custom metadata or noisy serialized API payloads when users call `str(chart)`.
- Add focused unit coverage for `BaseChart` and representative subclasses.

Closes #494.

## Validation
- `uv run pytest tests/unit/test_base_chart_str.py`
- `uv run ruff check ./datawrapper ./tests`
- `uv run ruff format --check ./datawrapper ./tests`
- `uv run mypy ./datawrapper --ignore-missing-imports`
- `uv run pytest`
- `uv build --sdist --wheel`
- `uv run pre-commit run --all-files`
