### PR TITLE
Fix LineChart custom area fill list deserialization

### DIFF
--- a/datawrapper/charts/line.py
+++ b/datawrapper/charts/line.py
@@ -152,19 +152,48 @@ class AreaFill(BaseModel):
         return result
 
     @classmethod
-    def deserialize_model(cls, api_data: dict[str, dict] | None) -> list[dict]:
+    def deserialize_model(
+        cls, api_data: dict[str, dict[str, Any]] | list[dict[str, Any]] | None
+    ) -> list[dict[str, Any]]:
         """Deserialize area fills from API response format.
 
+        Datawrapper has returned ``custom-area-fills`` in two valid shapes:
+        a keyed dictionary of fill IDs to fill data and a list of fill data
+        dictionaries. Support both shapes while failing explicitly for malformed
+        payloads.
+
         Args:
-            api_data: Dictionary mapping UUID keys to area fill data, or None
+            api_data: Dictionary mapping UUID keys to area fill data, list of
+                area fill data dictionaries, or None.
 
         Returns:
-            List of area fill dicts with 'id' field preserved
+            List of area fill dicts with any available ``id`` field preserved.
+
+        Raises:
+            TypeError: If api_data or one of its entries has an unexpected type.
         """
-        if not api_data:
+        if api_data is None:
             return []
 
-        return [{**fill_data, "id": fill_id} for fill_id, fill_data in api_data.items()]
+        if isinstance(api_data, dict):
+            fills: list[dict[str, Any]] = []
+            for fill_id, fill_data in api_data.items():
+                if not isinstance(fill_data, dict):
+                    raise TypeError(
+                        "custom-area-fills dict values must be dictionaries"
+                    )
+                fills.append({**fill_data, "id": fill_id})
+            return fills
+
+        if isinstance(api_data, list):
+            fills = []
+            for fill_data in api_data:
+                if not isinstance(fill_data, dict):
+                    raise TypeError("custom-area-fills list items must be dictionaries")
+                fills.append(fill_data.copy())
+            return fills
+
+        raise TypeError("custom-area-fills must be a dict, list, or None")
 
 
 class LineSymbol(BaseModel):

--- a/tests/integration/test_line_chart.py
+++ b/tests/integration/test_line_chart.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pandas as pd
+import pytest
 
 from datawrapper import LineChart
 
@@ -123,6 +124,106 @@ class TestLineChartCreation:
         assert fill["color"] == "#c3e8d5"
         assert fill["opacity"] == 0.7
 
+    def test_deserialize_area_fill_list_from_get_chart_response(self):
+        """Regression test for API responses that return custom-area-fills as a list."""
+        # Datawrapper can return custom-area-fills in the same list form this
+        # library serializes. Before v2.0.6 this path was permissive; the stricter
+        # AreaFill.deserialize_model implementation then assumed a dict and raised
+        # AttributeError: 'list' object has no attribute 'items'.
+        api_response = {
+            "type": "d3-lines",
+            "title": "List area fill response",
+            "metadata": {
+                "visualize": {
+                    "custom-area-fills": [
+                        {
+                            "id": "fill-list-1",
+                            "from": "baseline",
+                            "to": "value",
+                            "color": "#c3e8d5",
+                            "opacity": 0.7,
+                            "useMixedColors": False,
+                            "interpolation": "linear",
+                        }
+                    ]
+                }
+            },
+        }
+
+        init_data = LineChart.deserialize_model(api_response)
+
+        assert len(init_data["area_fills"]) == 1
+        area_fill = init_data["area_fills"][0]
+        assert area_fill.id == "fill-list-1"
+        assert area_fill.from_column == "baseline"
+        assert area_fill.to_column == "value"
+        assert area_fill.color == "#c3e8d5"
+        assert area_fill.opacity == 0.7
+
+    def test_deserialize_area_fill_dict_from_legacy_response(self):
+        """Test deserializing the keyed object shape used by older fixtures."""
+        api_response = {
+            "type": "d3-lines",
+            "title": "Dict area fill response",
+            "metadata": {
+                "visualize": {
+                    "custom-area-fills": {
+                        "legacy-fill-1": {
+                            "from": "lower",
+                            "to": "upper",
+                            "color": "#bcbcbc",
+                            "opacity": 0.49,
+                            "useMixedColors": False,
+                            "interpolation": "linear",
+                        }
+                    }
+                }
+            },
+        }
+
+        init_data = LineChart.deserialize_model(api_response)
+
+        assert len(init_data["area_fills"]) == 1
+        area_fill = init_data["area_fills"][0]
+        assert area_fill.id == "legacy-fill-1"
+        assert area_fill.from_column == "lower"
+        assert area_fill.to_column == "upper"
+
+    def test_deserialize_area_fill_empty_shapes(self):
+        """Test empty legacy and list shapes both deserialize to no area fills."""
+        for custom_area_fills in ({}, [], None):
+            init_data = LineChart.deserialize_model(
+                {
+                    "type": "d3-lines",
+                    "metadata": {"visualize": {"custom-area-fills": custom_area_fills}},
+                }
+            )
+
+            assert init_data["area_fills"] == []
+
+    @pytest.mark.parametrize(
+        ("custom_area_fills", "message"),
+        [
+            ("not-a-list-or-dict", "custom-area-fills must be a dict, list, or None"),
+            (["not-a-dict"], "custom-area-fills list items must be dictionaries"),
+            (
+                {"fill-1": "not-a-dict"},
+                "custom-area-fills dict values must be dictionaries",
+            ),
+        ],
+    )
+    def test_deserialize_area_fill_rejects_unexpected_shape(
+        self, custom_area_fills, message
+    ):
+        """Malformed custom-area-fills data should fail explicitly, not with AttributeError."""
+        api_response = {
+            "type": "d3-lines",
+            "metadata": {"visualize": {"custom-area-fills": custom_area_fills}},
+        }
+
+        with pytest.raises(TypeError, match=message):
+            LineChart.deserialize_model(api_response)
+
     def test_serialize_y_axis_scale(self):
         """Test serializing Y-axis scale configuration."""
         chart = LineChart(
@@ -158,6 +259,52 @@ class TestLineChartCreation:
 
 class TestLineChartGet:
     """Tests for LineChart.get() method."""
+
+    def test_get_with_custom_area_fills_list_response(self):
+        """Test get() with custom-area-fills in the list shape returned by the API."""
+        chart_metadata = {
+            "type": "d3-lines",
+            "title": "List area fill response",
+            "metadata": {
+                "visualize": {
+                    "custom-area-fills": [
+                        {
+                            "id": "fill-list-1",
+                            "from": "baseline",
+                            "to": "value",
+                            "color": "#c3e8d5",
+                            "opacity": 0.7,
+                            "useMixedColors": False,
+                            "interpolation": "linear",
+                        }
+                    ]
+                }
+            },
+        }
+        sample_csv = "date,baseline,value\n2024-01-01,0,10\n"
+
+        mock_client = Mock()
+        mock_client._CHARTS_URL = "https://api.datawrapper.de/v3/charts"
+
+        def mock_get(url):
+            if url.endswith("/data"):
+                return sample_csv
+            return chart_metadata
+
+        mock_client.get.side_effect = mock_get
+
+        with patch("datawrapper.charts.base.Datawrapper", return_value=mock_client):
+            chart = LineChart.get("customAreaFillList", access_token="test-token")
+
+        assert chart.chart_type == "d3-lines"
+        assert chart.title == "List area fill response"
+        assert len(chart.area_fills) == 1
+        area_fill = chart.area_fills[0]
+        assert area_fill.id == "fill-list-1"
+        assert area_fill.from_column == "baseline"
+        assert area_fill.to_column == "value"
+        assert area_fill.color == "#c3e8d5"
+        assert area_fill.opacity == 0.7
 
     def test_get_covid_sample(self):
         """Test get() with covid.json sample data (complex chart with area fills)."""


### PR DESCRIPTION
## Summary
- Fix `AreaFill.deserialize_model()` so `LineChart.get()` accepts `custom-area-fills` returned as a list by the Datawrapper API.
- Preserve support for the keyed dictionary shape used by existing legacy fixtures.
- Add explicit `TypeError` messages for malformed `custom-area-fills` payloads instead of leaking an incidental `AttributeError`.

## Reproduction
1. Mock or fetch a `d3-lines` chart payload whose `metadata.visualize.custom-area-fills` value is a list of fill dictionaries, e.g. `[{'id': 'fill-list-1', 'from': 'baseline', 'to': 'value', ...}]`.
2. Call `LineChart.deserialize_model(payload)` or `LineChart.get(chart_id)` on that response.
3. Before this fix, `AreaFill.deserialize_model()` assumed the value was a dictionary and called `.items()`, raising `AttributeError: 'list' object has no attribute 'items'`.

The regression test uses a deterministic mocked `LineChart.get()` payload and does not require live Datawrapper credentials.

## Root cause
`AreaFill.deserialize_model()` was narrowed to the legacy/keyed object shape for `custom-area-fills`, while the API can return the same list shape that the library serializes. The deserializer now branches on `dict`, `list`, and `None`, preserving IDs when present and rejecting malformed entries explicitly.

## Validation
- `uv run pytest tests/integration/test_line_chart.py -q` → 22 passed
- `uv run ruff check ./datawrapper ./tests` → All checks passed
- `uv run ruff format --check ./datawrapper ./tests` → 141 files already formatted
- `uv run mypy ./datawrapper --ignore-missing-imports` → Success: no issues found in 47 source files
- `uv build --sdist --wheel` → built sdist and wheel successfully; existing setuptools license deprecation warnings only
- `uv run pytest` → 1087 passed, 3 skipped

Closes #525