### PR TITLE
Fix refresh_data empty success responses

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -1404,7 +1404,7 @@ class Datawrapper:
         # Post it to the chart via the add_data method
         return self.add_data(chart_id, json_data)
 
-    def refresh_data(self, chart_id: str) -> dict:
+    def refresh_data(self, chart_id: str) -> dict | bool:
         """Fetch configured external data and add it to the chart.
 
         Parameters
@@ -1414,12 +1414,11 @@ class Datawrapper:
 
         Returns
         -------
-        dict
-            A dictionary containing the chart's information.
+        dict | bool
+            A dictionary containing the chart's information when returned by the API,
+            or True if the refresh succeeded without response data.
         """
-        response = self.post(f"{self._CHARTS_URL}/{chart_id}/data/refresh")
-        assert isinstance(response, dict)
-        return response
+        return self.post(f"{self._CHARTS_URL}/{chart_id}/data/refresh")
 
     #
     # Folder methods

--- a/tests/functional/test_main_coverage.py
+++ b/tests/functional/test_main_coverage.py
@@ -1,12 +1,12 @@
 """Comprehensive tests for uncovered methods in datawrapper/__main__.py with mocked API calls."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
 
 from datawrapper import Datawrapper
-from datawrapper.exceptions import InvalidRequestError
+from datawrapper.exceptions import FailedRequestError, InvalidRequestError
 
 
 class TestDeprecatedMethods:
@@ -150,6 +150,39 @@ class TestChartMethods:
             result = dw.refresh_data("chart123")
 
             assert "lastRefresh" in result
+            mock_post.assert_called_once()
+
+    def test_refresh_data_empty_success_response(self):
+        """Test refreshing external data when the API returns no response data."""
+        with patch("datawrapper.__main__.r.post") as mock_post:
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.status_code = 204
+            mock_response.text = ""
+            mock_post.return_value = mock_response
+
+            dw = Datawrapper(access_token="test_token")
+            result = dw.refresh_data("chart123")
+
+            assert result is True
+            mock_post.assert_called_once()
+            assert mock_post.call_args.args[0].endswith("/charts/chart123/data/refresh")
+
+    def test_refresh_data_error_response_raises_failed_request(self):
+        """Test that refresh_data preserves failed POST request behavior."""
+        with patch("datawrapper.__main__.r.post") as mock_post:
+            mock_response = Mock()
+            mock_response.ok = False
+            mock_response.status_code = 400
+            mock_response.content = b"Bad Request"
+            mock_post.return_value = mock_response
+
+            dw = Datawrapper(access_token="test_token")
+
+            with pytest.raises(FailedRequestError) as exc_info:
+                dw.refresh_data("chart123")
+
+            assert "400" in str(exc_info.value)
             mock_post.assert_called_once()
 
     def test_update_description_no_params(self):


### PR DESCRIPTION
## Summary

Fixes #418.

`Datawrapper.refresh_data()` assumed that a successful refresh response always parsed to a `dict`. The lower-level `post()` helper already supports successful empty responses by returning `True`, but `refresh_data()` immediately asserted that the result was a `dict`, causing an `AssertionError` even when the API refresh succeeded.

This change keeps the existing useful behavior for JSON/dict responses and also accepts successful empty-body responses by returning the helper result directly. The method annotation and docstring now reflect the actual return contract: `dict | bool`.

## Tests

- `uv run pytest tests/functional/test_main_coverage.py -k refresh_data`
- `uv run ruff check ./datawrapper ./tests`
- `uv run ruff format --check ./datawrapper ./tests`
- `uv run mypy ./datawrapper --ignore-missing-imports`
- `uv run pytest -q`
- `uv build --sdist --wheel`
- `uv run pre-commit run --all-files`

I did not run an additional live API smoke test for this PR because the issue already includes authenticated verification of the successful empty-response shape, and the regression tests reproduce both success shapes deterministically without exposing chart IDs, credentials, or API payloads.
