### PR TITLE
Support unsupported chart types via BaseChart shim

### DIFF
--- a/datawrapper/__main__.py
+++ b/datawrapper/__main__.py
@@ -699,8 +699,10 @@ class Datawrapper:
         """Creates a new Datawrapper chart, table or map.
 
         .. deprecated::
-            Use the object-oriented chart classes instead (e.g., BarChart, LineChart).
-            This method will be removed in a future version.
+            Prefer the object-oriented chart classes for supported chart types.
+            For maps, tables and other visualization types without a dedicated class,
+            this method remains a supported compatibility path until an
+            object-oriented replacement exists.
 
         Parameters
         ----------
@@ -734,9 +736,10 @@ class Datawrapper:
             A dictionary containing the created chart's information.
         """
         warnings.warn(
-            "create_chart() is deprecated and will be removed in a future version. "
-            "Use the object-oriented chart classes instead. "
-            "Example: chart = BarChart(title='My Chart', data=df).create()",
+            "create_chart() is deprecated for chart types with object-oriented classes. "
+            "For maps, tables and other unsupported visualization types it remains a "
+            "supported compatibility path until a dedicated class is available. "
+            "Example for supported charts: chart = BarChart(title='My Chart', data=df).create()",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -790,8 +793,10 @@ class Datawrapper:
         """Updates a chart's title, theme, type, language, folder or organization.
 
         .. deprecated::
-            Use the object-oriented chart classes instead (e.g., BarChart, LineChart).
-            This method will be removed in a future version.
+            Prefer the object-oriented chart classes for supported chart types.
+            For maps, tables and other visualization types without a dedicated class,
+            this method remains a supported compatibility path until an
+            object-oriented replacement exists.
 
         Parameters
         ----------
@@ -830,9 +835,10 @@ class Datawrapper:
             If no updates are submitted.
         """
         warnings.warn(
-            "update_chart() is deprecated and will be removed in a future version. "
-            "Use the object-oriented chart classes instead. "
-            "Example: chart = BarChart.get(chart_id='abc123'); chart.title = 'New Title'; chart.update()",
+            "update_chart() is deprecated for chart types with object-oriented classes. "
+            "For maps, tables and other unsupported visualization types it remains a "
+            "supported compatibility path until a dedicated class is available. "
+            "Example for supported charts: chart = BarChart.get(chart_id='abc123'); chart.title = 'New Title'; chart.update()",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1098,8 +1104,10 @@ class Datawrapper:
         """Publishes a chart, table or map.
 
         .. deprecated::
-            Use the object-oriented chart classes instead (e.g., BarChart, LineChart).
-            This method will be removed in a future version.
+            Prefer the object-oriented chart classes for supported chart types.
+            For maps, tables and other visualization types without a dedicated class,
+            this method remains a supported compatibility path until an
+            object-oriented replacement exists.
 
         Parameters
         ----------
@@ -1115,9 +1123,10 @@ class Datawrapper:
             object displaying the chart.
         """
         warnings.warn(
-            "publish_chart() is deprecated and will be removed in a future version. "
-            "Use the object-oriented chart classes instead. "
-            "Example: chart = BarChart.get(chart_id='abc123'); chart.publish()",
+            "publish_chart() is deprecated for chart types with object-oriented classes. "
+            "For maps, tables and other unsupported visualization types it remains a "
+            "supported compatibility path until a dedicated class is available. "
+            "Example for supported charts: chart = BarChart.get(chart_id='abc123'); chart.publish()",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1334,8 +1343,10 @@ class Datawrapper:
         """Add data to a specified chart.
 
         .. deprecated::
-            Use the object-oriented chart classes instead (e.g., BarChart, LineChart).
-            This method will be removed in a future version.
+            Prefer the object-oriented chart classes for supported chart types.
+            For maps, tables and other visualization types without a dedicated class,
+            this method remains a supported compatibility path until an
+            object-oriented replacement exists.
 
         Parameters
         ----------
@@ -1351,9 +1362,10 @@ class Datawrapper:
             True if the data was added successfully.
         """
         warnings.warn(
-            "add_data() is deprecated and will be removed in a future version. "
-            "Use the object-oriented chart classes instead. "
-            "Example: chart = BarChart(title='My Chart', data=df).create() or chart.data = df; chart.update()",
+            "add_data() is deprecated for chart types with object-oriented classes. "
+            "For maps, tables and other unsupported visualization types it remains a "
+            "supported compatibility path until a dedicated class is available. "
+            "Example for supported charts: chart = BarChart(title='My Chart', data=df).create() or chart.data = df; chart.update()",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/datawrapper/chart_factory.py
+++ b/datawrapper/chart_factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -22,10 +23,12 @@ def get_chart(chart_id: str, access_token: str | None = None) -> BaseChart:
             will attempt to use the DATAWRAPPER_ACCESS_TOKEN environment variable.
 
     Returns:
-        BaseChart: A typed chart instance (LineChart, BarChart, ColumnChart, etc.)
+        BaseChart: A typed chart instance when the chart type is supported, or a
+        BaseChart compatibility instance for maps, tables and other Datawrapper
+        visualization types that do not yet have a dedicated class.
 
     Raises:
-        ValueError: If the chart type is not supported
+        ValueError: If the chart metadata is missing a type
         FailedRequestError: If the API request fails
         InvalidRequestError: If the request is invalid
 
@@ -43,6 +46,7 @@ def get_chart(chart_id: str, access_token: str | None = None) -> BaseChart:
         AreaChart,
         ArrowChart,
         BarChart,
+        BaseChart,
         ColumnChart,
         LineChart,
         MultipleColumnChart,
@@ -73,13 +77,20 @@ def get_chart(chart_id: str, access_token: str | None = None) -> BaseChart:
     if not chart_type:
         raise ValueError(f"Chart {chart_id} has no type field in metadata")
 
-    # Get the appropriate chart class
+    # Get the appropriate chart class. Unsupported types intentionally fall back to
+    # BaseChart so users can still create, fetch, update and publish maps, tables and
+    # newly introduced Datawrapper types while dedicated classes are added gradually.
     chart_class = chart_type_map.get(chart_type)
     if not chart_class:
-        raise ValueError(
-            f"Unsupported chart type: {chart_type}. "
-            f"Supported types: {', '.join(chart_type_map.keys())}"
+        warnings.warn(
+            f"Chart type {chart_type!r} does not have a dedicated datawrapper class yet. "
+            "Returning BaseChart as a compatibility shim; raw metadata is preserved "
+            "for round-trip updates, but chart-specific convenience fields are not "
+            "available until a dedicated class is added.",
+            UserWarning,
+            stacklevel=2,
         )
+        chart_class = BaseChart
 
     # Cast to satisfy type checkers while avoiding circular imports
     # Use string literal to avoid NameError at runtime

--- a/datawrapper/charts/base.py
+++ b/datawrapper/charts/base.py
@@ -1,11 +1,12 @@
 import os
 import warnings
+from copy import deepcopy
 from io import StringIO
 from typing import Any, Literal
 
 import pandas as pd
 from IPython.display import IFrame
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from datawrapper.__main__ import Datawrapper
 from datawrapper.charts.models import Annotate, Describe, Publish, Transform, Visualize
@@ -71,18 +72,13 @@ class BaseChart(BaseModel):
         },
     )
 
-    #: The type of datawrapper chart to create
-    chart_type: Literal[
-        "column-chart",
-        "d3-area",
-        "d3-arrow-plot",
-        "d3-bars",
-        "d3-bars-stacked",
-        "d3-lines",
-        "d3-scatter-plot",
-        "locator-map",
-        "multiple-columns",
-    ] = Field(alias="chart-type", description="The type of datawrapper chart to create")
+    #: The Datawrapper visualization type to create. Typed subclasses narrow this
+    #: field to the chart types they fully model, while BaseChart intentionally
+    #: accepts any non-empty type supported by the Datawrapper API so maps, tables
+    #: and newly added visualization types still have an object-oriented path.
+    chart_type: str = Field(
+        alias="chart-type", description="The type of datawrapper chart to create"
+    )
 
     #
     # Data
@@ -246,6 +242,29 @@ class BaseChart(BaseModel):
         exclude=True,  # Don't include in serialization
     )
 
+    #: Raw Datawrapper metadata loaded from the API. This is primarily used by the
+    #: BaseChart compatibility shim to preserve map, table and newly added
+    #: visualization settings that do not yet have typed Python fields.
+    raw_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        alias="metadata",
+        description="Raw Datawrapper metadata preserved for compatibility",
+        exclude=True,
+    )
+
+    @field_validator("chart_type")
+    @classmethod
+    def validate_chart_type(cls, value: str) -> str:
+        """Require a non-empty Datawrapper visualization type.
+
+        The base class deliberately avoids a hardcoded allowlist so it can act as a
+        compatibility shim for chart, map and table types that do not yet have a
+        typed Python class. Subclasses keep their narrower Literal annotations.
+        """
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("chart_type must be a non-empty string")
+        return value
+
     #
     # Serialization methods for preparing data for API upload
     #
@@ -321,15 +340,24 @@ class BaseChart(BaseModel):
             }
         )
 
-        # Create the metadata section in the proper Datawrapper order
-        dw_obj["metadata"] = {
+        # Create the metadata section in the proper Datawrapper order. Start with
+        # raw API metadata when present so BaseChart can round-trip unsupported
+        # map/table/new-type settings while still overlaying the common typed fields.
+        metadata = deepcopy(self.raw_metadata) if self.raw_metadata else {}
+        for section_name, section_data in {
             "data": data_section,
             "describe": describe.model_dump(by_alias=True),
             "visualize": visualize.model_dump(by_alias=True),
             "publish": publish.model_dump(by_alias=True),
             "annotate": annotate.model_dump(by_alias=True),
-            "custom": self.custom,
-        }
+        }.items():
+            existing_section = metadata.get(section_name)
+            if isinstance(existing_section, dict):
+                metadata[section_name] = {**existing_section, **section_data}
+            else:
+                metadata[section_name] = section_data
+        metadata["custom"] = self.custom
+        dw_obj["metadata"] = metadata
 
         # Return the obj
         return dw_obj
@@ -482,8 +510,9 @@ class BaseChart(BaseModel):
             "share_url": visualize_sharing.get("url"),
             "logo": publish_logo.get("enabled"),
             "logo_id": publish_logo.get("id"),
-            # Custom
+            # Custom and raw metadata compatibility
             "custom": metadata.get("custom"),
+            "raw_metadata": metadata,
         }
 
         # Remove None values to let Pydantic apply model defaults
@@ -649,17 +678,24 @@ class BaseChart(BaseModel):
         # Get the serialized chart metadata
         metadata = self.serialize_model()
 
-        # Use the convenience method from the client to create the chart
-        response = client.create_chart(
-            title=metadata["title"],
-            chart_type=metadata["type"],
-            theme=metadata.get("theme") or None,
-            data=self.serialize_data(),
-            forkable=self.forkable,
-            language=metadata.get("language"),
-            metadata=metadata["metadata"],
-            folder_id=folder_id,
-        )
+        # Use the compatibility client method without surfacing its legacy-method
+        # deprecation warning to users already using the object-oriented API.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"create_chart\(\) is deprecated.*",
+                category=DeprecationWarning,
+            )
+            response = client.create_chart(
+                title=metadata["title"],
+                chart_type=metadata["type"],
+                theme=metadata.get("theme") or None,
+                data=self.serialize_data(),
+                forkable=self.forkable,
+                language=metadata.get("language"),
+                metadata=metadata["metadata"],
+                folder_id=folder_id,
+            )
 
         # Extract and validate the chart ID
         if not isinstance(response, dict):
@@ -697,16 +733,23 @@ class BaseChart(BaseModel):
         # Get the serialized chart metadata
         metadata = self.serialize_model()
 
-        # Use the convenience method from the client to update the chart
-        client.update_chart(
-            chart_id=self.chart_id,
-            title=metadata["title"],
-            chart_type=metadata["type"],
-            theme=metadata.get("theme") or None,
-            data=self.serialize_data(),
-            language=metadata.get("language"),
-            metadata=metadata["metadata"],
-        )
+        # Use the compatibility client method without surfacing its legacy-method
+        # deprecation warning to users already using the object-oriented API.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"update_chart\(\) is deprecated.*",
+                category=DeprecationWarning,
+            )
+            client.update_chart(
+                chart_id=self.chart_id,
+                title=metadata["title"],
+                chart_type=metadata["type"],
+                theme=metadata.get("theme") or None,
+                data=self.serialize_data(),
+                language=metadata.get("language"),
+                metadata=metadata["metadata"],
+            )
 
         # Return self for chaining
         return self
@@ -736,8 +779,15 @@ class BaseChart(BaseModel):
         # Get the client
         client = self._get_client(access_token)
 
-        # Call the publish_chart method from the client
-        result = client.publish_chart(chart_id=self.chart_id)
+        # Call the compatibility client method without surfacing its legacy-method
+        # deprecation warning to users already using the object-oriented API.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"publish_chart\(\) is deprecated.*",
+                category=DeprecationWarning,
+            )
+            result = client.publish_chart(chart_id=self.chart_id)
 
         # Raise an exception if publishing failed
         if not result:

--- a/docs/user-guide/chart-operations.md
+++ b/docs/user-guide/chart-operations.md
@@ -154,3 +154,63 @@ Path("chart.png").write_bytes(png_data)
 Path("chart.pdf").write_bytes(pdf_data)
 Path("chart.svg").write_bytes(svg_data)
 ```
+
+## Compatibility for maps, tables and newer Datawrapper types
+
+The object-oriented API is the preferred path for chart types that have dedicated
+classes, such as `BarChart`, `LineChart`, `ColumnChart` and `ScatterPlot`. The
+older `Datawrapper.create_chart()`, `Datawrapper.update_chart()`,
+`Datawrapper.add_data()` and `Datawrapper.publish_chart()` methods are deprecated
+for those supported chart classes, but they are not scheduled for removal for
+maps, tables or other Datawrapper visualization types until equivalent
+object-oriented classes exist.
+
+For unsupported types, use one of these compatible migration paths:
+
+```python
+import pandas as pd
+import datawrapper as dw
+
+# Forward-compatible object-oriented shim. This works for any non-empty
+# Datawrapper visualization type, including maps that do not yet have a
+# dedicated Python class.
+chart = dw.BaseChart(
+    chart_type="d3-maps-choropleth",
+    title="Population by region",
+    data=pd.DataFrame({"region": ["CA", "NY"], "value": [39.0, 19.6]}),
+)
+chart.create()
+chart.publish()
+```
+
+You can also keep using the legacy client methods for unsupported types when you
+need to pass raw Datawrapper metadata:
+
+```python
+client = dw.Datawrapper()
+chart = client.create_chart(
+    title="Population by region",
+    chart_type="d3-maps-choropleth",
+)
+client.update_chart(
+    chart["id"],
+    metadata={"visualize": {"basemap": "usa-states"}},
+)
+client.publish_chart(chart["id"])
+```
+
+`dw.get_chart(chart_id)` returns a dedicated chart class when one is available.
+When the Datawrapper API reports a type that is not yet modeled by this package,
+it now returns `BaseChart` with a warning instead of failing as unsupported. This
+keeps existing maps and newly released Datawrapper visualization types usable
+while making it clear that chart-specific convenience fields are not available
+until a dedicated class is added.
+
+### Deprecation timeline
+
+- Dedicated chart classes are the future-facing API for supported types.
+- Legacy client methods remain available for unsupported maps, tables and new
+  visualization types until a dedicated replacement exists.
+- After a dedicated class lands for a type, the corresponding legacy-method use
+  for that type should go through at least one minor release with clear warnings
+  and migration examples before removal is considered in a future major release.

--- a/tests/functional/test_chart_factory.py
+++ b/tests/functional/test_chart_factory.py
@@ -9,6 +9,7 @@ from datawrapper.charts import (
     AreaChart,
     ArrowChart,
     BarChart,
+    BaseChart,
     ColumnChart,
     LineChart,
     MultipleColumnChart,
@@ -330,24 +331,36 @@ def test_get_chart_missing_type():
             get_chart(chart_id="notype777")
 
 
-def test_get_chart_unsupported_type():
-    """Test get_chart raises ValueError for unsupported chart types."""
+def test_get_chart_unsupported_type_returns_base_chart():
+    """Test get_chart returns BaseChart for unsupported but valid chart types."""
     # Create a mock Datawrapper client
     mock_client = MagicMock(spec=Datawrapper)
 
-    # Mock get_chart response with unsupported type
+    # Mock get_chart response with an unsupported type
     mock_metadata = {
         "id": "unsupported888",
         "title": "Test Chart",
-        "type": "d3-maps",  # Unsupported type
+        "type": "d3-maps",
         "metadata": {"visualize": {}},
     }
     mock_client.get_chart.return_value = mock_metadata
 
-    with patch("datawrapper.Datawrapper", return_value=mock_client):
-        # Call get_chart should raise ValueError
-        with pytest.raises(ValueError, match="Unsupported chart type: d3-maps"):
-            get_chart(chart_id="unsupported888")
+    with (
+        patch("datawrapper.Datawrapper", return_value=mock_client),
+        patch.object(BaseChart, "get") as mock_base_get,
+    ):
+        mock_chart = BaseChart(chart_type="d3-maps", title="Test Chart")
+        mock_chart.chart_id = "unsupported888"
+        mock_base_get.return_value = mock_chart
+
+        with pytest.warns(
+            UserWarning, match="does not have a dedicated datawrapper class"
+        ):
+            result = get_chart(chart_id="unsupported888")
+
+    assert isinstance(result, BaseChart)
+    assert result.chart_id == "unsupported888"
+    mock_base_get.assert_called_once_with(chart_id="unsupported888", access_token=None)
 
 
 def test_get_chart_all_supported_types():

--- a/tests/functional/test_deprecation_compatibility.py
+++ b/tests/functional/test_deprecation_compatibility.py
@@ -1,0 +1,123 @@
+"""Compatibility tests for legacy client method deprecations."""
+
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datawrapper import BaseChart, Datawrapper
+
+
+def test_update_chart_warning_documents_compatibility_for_maps():
+    """Legacy updates should be deprecated only where a typed class exists."""
+    client = Datawrapper()
+
+    with patch.object(Datawrapper, "patch", return_value={"id": "map123"}):
+        with pytest.warns(DeprecationWarning) as warnings_record:
+            client.update_chart(
+                "map123",
+                chart_type="d3-maps-choropleth",
+                metadata={"visualize": {"basemap": "world"}},
+            )
+
+    message = str(warnings_record[0].message)
+    assert "deprecated for chart types with object-oriented classes" in message
+    assert "maps, tables and other unsupported visualization types" in message
+    assert "supported compatibility path" in message
+
+
+def test_base_chart_accepts_unsupported_map_type_as_forward_compatible_shim():
+    """BaseChart should support map types that lack a dedicated class."""
+    chart = BaseChart(
+        chart_type="d3-maps-choropleth",
+        title="Map example",
+        custom={"source": "issue-522"},
+    )
+
+    assert chart.chart_type == "d3-maps-choropleth"
+    serialized = chart.serialize_model()
+    assert serialized["type"] == "d3-maps-choropleth"
+    assert serialized["title"] == "Map example"
+
+
+def test_base_chart_preserves_raw_metadata_for_unsupported_types():
+    """The fallback shim should not discard unsupported chart-specific settings."""
+    parsed = BaseChart.deserialize_model(
+        {
+            "id": "map123",
+            "title": "Map example",
+            "type": "d3-maps-choropleth",
+            "metadata": {
+                "visualize": {
+                    "basemap": "usa-states",
+                    "colors": {"palette": "YlOrRd"},
+                },
+                "custom": {"source": "issue-522"},
+            },
+        }
+    )
+    chart = BaseChart(**parsed)
+
+    serialized = chart.serialize_model()
+    assert serialized["metadata"]["visualize"]["basemap"] == "usa-states"
+    assert serialized["metadata"]["visualize"]["colors"] == {"palette": "YlOrRd"}
+    assert serialized["metadata"]["custom"] == {"source": "issue-522"}
+
+
+@pytest.mark.parametrize("method_name", ["create", "update", "publish"])
+def test_base_chart_methods_do_not_emit_internal_legacy_warnings(method_name):
+    """Object-oriented calls should not leak warnings from legacy client internals."""
+    chart = BaseChart(chart_type="d3-maps-choropleth", title="Map example")
+    chart._client = Datawrapper()
+
+    if method_name == "create":
+
+        def create_chart_with_warning(**kwargs):
+            warnings.warn(
+                "create_chart() is deprecated for chart types with object-oriented classes.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return {"id": "map123"}
+
+        mock_method = MagicMock(side_effect=create_chart_with_warning)
+        with patch.object(Datawrapper, "create_chart", mock_method):
+            with warnings.catch_warnings(record=True) as warnings_record:
+                warnings.simplefilter("always")
+                chart.create()
+        assert chart.chart_id == "map123"
+    elif method_name == "update":
+        chart.chart_id = "map123"
+
+        def update_chart_with_warning(**kwargs):
+            warnings.warn(
+                "update_chart() is deprecated for chart types with object-oriented classes.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return {"id": "map123"}
+
+        mock_method = MagicMock(side_effect=update_chart_with_warning)
+        with patch.object(Datawrapper, "update_chart", mock_method):
+            with warnings.catch_warnings(record=True) as warnings_record:
+                warnings.simplefilter("always")
+                chart.update()
+    else:
+        chart.chart_id = "map123"
+
+        def publish_chart_with_warning(**kwargs):
+            warnings.warn(
+                "publish_chart() is deprecated for chart types with object-oriented classes.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return {"ok": True}
+
+        mock_method = MagicMock(side_effect=publish_chart_with_warning)
+        with patch.object(Datawrapper, "publish_chart", mock_method):
+            with warnings.catch_warnings(record=True) as warnings_record:
+                warnings.simplefilter("always")
+                chart.publish()
+
+    mock_method.assert_called_once()
+    assert not warnings_record

--- a/tests/functional/test_public_api_guardrails.py
+++ b/tests/functional/test_public_api_guardrails.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from datawrapper import BarChart, Datawrapper, get_chart
+from datawrapper import BarChart, BaseChart, Datawrapper, get_chart
 
 
 @pytest.mark.parametrize(
@@ -12,13 +12,12 @@ from datawrapper import BarChart, Datawrapper, get_chart
     [
         (None, "has no type field in metadata"),
         ("", "has no type field in metadata"),
-        ("unknown-chart-type", "Unsupported chart type: unknown-chart-type"),
     ],
 )
-def test_get_chart_rejects_missing_or_unsupported_chart_types(
+def test_get_chart_rejects_missing_chart_types(
     clean_env, metadata_type, expected_error
 ):
-    """The typed chart factory must fail clearly instead of guessing a class."""
+    """The chart factory must fail clearly when metadata does not include a type."""
     mock_client = MagicMock(spec=Datawrapper)
     mock_client.get_chart.return_value = {
         "id": "chart-123",
@@ -32,6 +31,32 @@ def test_get_chart_rejects_missing_or_unsupported_chart_types(
             get_chart("chart-123")
 
     mock_client.get_chart.assert_called_once_with("chart-123")
+
+
+def test_get_chart_unsupported_type_returns_base_chart_with_warning(clean_env):
+    """Unsupported types should use the BaseChart compatibility shim."""
+    mock_client = MagicMock(spec=Datawrapper)
+    mock_client.get_chart.return_value = {
+        "id": "map-123",
+        "title": "Unsupported map",
+        "type": "d3-maps-choropleth",
+        "metadata": {"visualize": {}},
+    }
+
+    with (
+        patch("datawrapper.Datawrapper", return_value=mock_client),
+        patch.object(
+            BaseChart, "get", return_value=BaseChart(chart_type="d3-maps-choropleth")
+        ) as mock_get,
+    ):
+        with pytest.warns(
+            UserWarning, match="does not have a dedicated datawrapper class"
+        ):
+            result = get_chart("map-123")
+
+    assert isinstance(result, BaseChart)
+    assert result.chart_type == "d3-maps-choropleth"
+    mock_get.assert_called_once_with(chart_id="map-123", access_token=None)
 
 
 def test_get_chart_prefers_explicit_token_over_environment(env_with_token):

--- a/tests/unit/models/charts/test_base_chart.py
+++ b/tests/unit/models/charts/test_base_chart.py
@@ -64,5 +64,5 @@ def test_base_chart():
     with pytest.raises(ValueError):
         datawrapper.BaseChart.model_validate({"chart_type": 123})
 
-    with pytest.raises(ValueError):
-        datawrapper.BaseChart.model_validate({"chart_type": "invalid_type"})
+    chart = datawrapper.BaseChart.model_validate({"chart_type": "d3-maps-choropleth"})
+    assert chart.chart_type == "d3-maps-choropleth"


### PR DESCRIPTION
## Summary
- Keep typed chart classes as the preferred path, but make `BaseChart` a forward-compatible shim for Datawrapper visualization types that do not yet have dedicated classes, including `d3-maps-choropleth`.
- Change `dw.get_chart(chart_id)` so supported types still return dedicated classes, missing/empty types still fail clearly, and unsupported non-empty types return `BaseChart` with a `UserWarning` instead of raising `ValueError`.
- Preserve raw API metadata on `BaseChart` so unsupported map/table/new-type settings can round-trip through `serialize_model()`.
- Clarify legacy `Datawrapper.create_chart()`, `update_chart()`, `add_data()` and `publish_chart()` warnings/docs: deprecated for supported object-oriented chart classes, but still a compatibility path for maps, tables and other unsupported visualization types until dedicated classes exist.
- Add docs and focused tests for the deprecation timeline, migration path, warnings, fallback behavior and metadata preservation.

Closes #522.

## Deprecation timeline and migration path
- **Preferred API now:** use dedicated object-oriented classes (`BarChart`, `LineChart`, `ColumnChart`, etc.) where they exist.
- **Compatibility API now:** use `BaseChart(chart_type="d3-maps-choropleth", ...)` or `dw.get_chart(chart_id)` for maps, tables and newer Datawrapper visualization types that are not yet modeled by this package.
- **Legacy client methods:** `Datawrapper.create_chart()`, `update_chart()`, `add_data()` and `publish_chart()` remain available as a compatibility path for unsupported types until a dedicated replacement exists.
- **Future removals:** once a dedicated class exists for a currently unsupported type, legacy-method use for that type should go through at least one minor release with explicit warnings and migration examples before any removal is considered in a future major release.

## User impact
- Users trying to create or update map types such as `d3-maps-choropleth` now have a documented, tested path.
- Existing `get_chart()` calls for unsupported but valid Datawrapper types no longer fail immediately; they return `BaseChart` with a warning that chart-specific convenience fields are unavailable.
- Existing typed chart workflows remain unchanged.

## Deliberately deferred
- This does not add dedicated map/table classes or type-specific convenience fields.
- It does not remove legacy client methods.
- It does not attempt live API coverage; tests are mocked/local per project guidance.

## Validation
- `uv sync --frozen --all-extras`
- `uv run ruff check ./datawrapper ./tests`
- `uv run ruff format --check ./datawrapper ./tests`
- `uv run mypy ./datawrapper --ignore-missing-imports`
- `uv build --sdist --wheel` *(passes; emits existing setuptools license deprecation warnings)*
- `uv run pytest` *(1095 passed, 3 skipped)*
- `uv run pre-commit run --all-files`
