### PR TITLE
Add Line color convenience mapping

### DIFF
--- a/datawrapper/charts/line.py
+++ b/datawrapper/charts/line.py
@@ -819,7 +819,14 @@ class LineChart(
                 raise ValueError(f"Invalid value: {v}. Must be one of {valid_values}")
         return v
 
-    def _color_category_from_lines(self) -> dict[str, str]:
+    def _validated_lines(self) -> list[Line]:
+        """Return line configs as Line models, validating dict inputs once."""
+        return [
+            Line.model_validate(line_obj) if isinstance(line_obj, dict) else line_obj
+            for line_obj in self.lines
+        ]
+
+    def _color_category_from_lines(self, lines: list[Line]) -> dict[str, str]:
         """Return color-category entries declared on individual Line objects.
 
         Line.color is a convenience interface for the chart-level
@@ -827,18 +834,13 @@ class LineChart(
         inside Datawrapper's per-line config object.
         """
         line_colors: dict[str, str] = {}
-        for line_obj in self.lines:
-            if isinstance(line_obj, dict):
-                line_config = Line.model_validate(line_obj)
-            else:
-                line_config = line_obj
-
+        for line_config in lines:
             if line_config.color is not None:
                 line_colors[line_config.column] = line_config.color
 
         return line_colors
 
-    def _merged_color_category(self) -> dict[str, str]:
+    def _merged_color_category(self, lines: list[Line]) -> dict[str, str]:
         """Merge legacy color_category with Line.color convenience values.
 
         Explicit color_category values remain fully supported. When a line-level
@@ -847,7 +849,7 @@ class LineChart(
         over the other for ambiguous input.
         """
         color_category = dict(self.color_category)
-        for column, color in self._color_category_from_lines().items():
+        for column, color in self._color_category_from_lines(lines).items():
             if column in color_category and color_category[column] != color:
                 raise ValueError(
                     "Conflicting colors for line "
@@ -863,7 +865,8 @@ class LineChart(
         """Serialize the model to a dictionary."""
         # Call the parent class's serialize_model method
         model = super().serialize_model()
-        color_category = self._merged_color_category()
+        line_configs = self._validated_lines()
+        color_category = self._merged_color_category(line_configs)
 
         # Set the axes setting if x_column is provided
         if self.x_column:
@@ -913,12 +916,7 @@ class LineChart(
         model["metadata"]["visualize"].update(self._serialize_annotations())
 
         # Add line configurations
-        for line_obj in self.lines:
-            if isinstance(line_obj, dict):
-                line_config = Line.model_validate(line_obj)
-            else:
-                line_config = line_obj
-
+        for line_config in line_configs:
             line_name = line_config.column
             model["metadata"]["visualize"]["lines"][line_name] = Line.serialize_model(
                 line_config

--- a/datawrapper/charts/line.py
+++ b/datawrapper/charts/line.py
@@ -407,6 +407,17 @@ class Line(BaseModel):
             )
         return v
 
+    #: The line color. This is a convenience interface for LineChart.color_category.
+    #: During LineChart serialization, each Line.color value is merged into the
+    #: chart-level color_category mapping using the line's column name.
+    color: str | None = Field(
+        default=None,
+        description=(
+            "The line color (hex string or Datawrapper-supported color value). "
+            "This is a convenience interface for LineChart.color_category."
+        ),
+    )
+
     #: Whether or not to show in the color key
     color_key: bool = Field(
         default=False,
@@ -546,6 +557,8 @@ class Line(BaseModel):
             init_dict["interpolation"] = line_config["interpolation"]
         if "width" in line_config:
             init_dict["width"] = line_config["width"]
+        if "color" in line_config:
+            init_dict["color"] = line_config["color"]
 
         # Always include dash field (None if not present in API response)
         init_dict["dash"] = line_config.get("dash")
@@ -806,10 +819,51 @@ class LineChart(
                 raise ValueError(f"Invalid value: {v}. Must be one of {valid_values}")
         return v
 
+    def _color_category_from_lines(self) -> dict[str, str]:
+        """Return color-category entries declared on individual Line objects.
+
+        Line.color is a convenience interface for the chart-level
+        color_category mapping. It intentionally does not replace or serialize
+        inside Datawrapper's per-line config object.
+        """
+        line_colors: dict[str, str] = {}
+        for line_obj in self.lines:
+            if isinstance(line_obj, dict):
+                line_config = Line.model_validate(line_obj)
+            else:
+                line_config = line_obj
+
+            if line_config.color is not None:
+                line_colors[line_config.column] = line_config.color
+
+        return line_colors
+
+    def _merged_color_category(self) -> dict[str, str]:
+        """Merge legacy color_category with Line.color convenience values.
+
+        Explicit color_category values remain fully supported. When a line-level
+        convenience color names a column that is also present in color_category,
+        the values must match. Raising here avoids silently choosing one source
+        over the other for ambiguous input.
+        """
+        color_category = dict(self.color_category)
+        for column, color in self._color_category_from_lines().items():
+            if column in color_category and color_category[column] != color:
+                raise ValueError(
+                    "Conflicting colors for line "
+                    f"{column!r}: color_category has {color_category[column]!r} "
+                    f"but Line.color has {color!r}. Use one source of truth or "
+                    "make the values match."
+                )
+            color_category[column] = color
+
+        return color_category
+
     def serialize_model(self) -> dict:
         """Serialize the model to a dictionary."""
         # Call the parent class's serialize_model method
         model = super().serialize_model()
+        color_category = self._merged_color_category()
 
         # Set the axes setting if x_column is provided
         if self.x_column:
@@ -831,7 +885,7 @@ class LineChart(
             "base-color": self.base_color,
             "interpolation": self.interpolation,
             "connector-lines": self.connector_lines,
-            "color-category": ColorCategory.serialize(self.color_category),
+            "color-category": ColorCategory.serialize(color_category),
             # Labels
             "stack-color-legend": self.stack_color_legend,
             "label-colors": self.label_colors,
@@ -920,7 +974,9 @@ class LineChart(
         if "connector-lines" in visualize:
             init_data["connector_lines"] = visualize["connector-lines"]
 
-        # Parse color-category using utility
+        # Parse color-category using utility. Preserve the legacy chart-level
+        # color_category mapping as the source of truth during deserialization;
+        # line-level colors are a write-time convenience only.
         color_data = ColorCategory.deserialize(visualize.get("color-category"))
         init_data["color_category"] = color_data["color_category"]
 

--- a/docs/user-guide/charts/line-charts.md
+++ b/docs/user-guide/charts/line-charts.md
@@ -36,14 +36,12 @@ chart = dw.LineChart(
     # And now the tooltip with a bit more...
     tooltip_number_format="00.00",
     tooltip_x_format="YYYY",
-    # Configure the main temperature line's color
-    color_category={
-        "LandAverageTemperature": "#1d81a2",
-    },
     lines=[
-        # Style the main line
+        # Style the main line. The color argument is a line-centric
+        # convenience for the chart's color_category map.
         dw.Line(
             column="LandAverageTemperature",
+            color="#1d81a2",
             width=dw.LineWidth.THIN,
             interpolation=dw.LineInterpolation.CURVED,
         ),
@@ -70,6 +68,22 @@ chart = dw.LineChart(
 
 chart.create()
 ```
+
+You can also keep colors in the legacy chart-level mapping when that better fits
+existing code or shared category settings:
+
+```python
+chart = dw.LineChart(
+    data=df,
+    color_category={"LandAverageTemperature": "#1d81a2"},
+    lines=[dw.Line(column="LandAverageTemperature", width=dw.LineWidth.THIN)],
+)
+```
+
+`Line(color=...)` and `LineChart(color_category=...)` serialize to the same
+Datawrapper `color-category` metadata. If both are provided for the same line,
+the colors must match; conflicting values raise an error instead of silently
+choosing one.
 
 ## Reference
 

--- a/tests/integration/test_line_chart.py
+++ b/tests/integration/test_line_chart.py
@@ -84,19 +84,23 @@ class TestLineChartCreation:
                     "width": "style3",
                     "dash": "style2",
                     "direct_label": True,
+                    "color": "#15607a",
                     "symbols": {"enabled": True, "shape": "square", "on": "last"},
                 }
             ],
         )
 
         serialized = chart.serialize_model()
-        line_config = serialized["metadata"]["visualize"]["lines"]["y"]
+        visualize = serialized["metadata"]["visualize"]
+        line_config = visualize["lines"]["y"]
 
         assert line_config["width"] == "style3"
         assert line_config["dash"] == "style2"
         assert line_config["directLabel"] is True
         assert line_config["symbols"]["enabled"] is True
         assert line_config["symbols"]["shape"] == "square"
+        assert "color" not in line_config
+        assert visualize["color-category"]["map"] == {"y": "#15607a"}
 
     def test_serialize_with_area_fill(self):
         """Test serializing with area fills."""

--- a/tests/unit/models/test_line_color.py
+++ b/tests/unit/models/test_line_color.py
@@ -1,0 +1,107 @@
+"""Tests for Line.color convenience color mapping."""
+
+import pytest
+
+from datawrapper.charts.line import Line, LineChart
+
+
+def test_line_accepts_color_convenience_value():
+    """Line.color stores a color without serializing it into line config."""
+    line = Line(column="sales", color="#ff0000")
+
+    assert line.color == "#ff0000"
+    assert "color" not in Line.serialize_model(line)
+
+
+def test_line_color_deserialization_preserves_unexpected_line_color():
+    """If API line config ever contains color, keep it rather than dropping data."""
+    line_dict = Line.deserialize_model("sales", {"color": "#ff0000"})
+
+    assert line_dict["color"] == "#ff0000"
+    assert Line(**line_dict).color == "#ff0000"
+
+
+def test_line_color_merges_into_color_category_serialization():
+    """Line.color is serialized through Datawrapper's color-category map."""
+    chart = LineChart(
+        title="Line colors",
+        lines=[Line(column="sales", color="#ff0000")],
+    )
+
+    visualize = chart.serialize_model()["metadata"]["visualize"]
+
+    assert visualize["color-category"] == {"map": {"sales": "#ff0000"}}
+    assert "color" not in visualize["lines"]["sales"]
+
+
+def test_legacy_color_category_serialization_is_unchanged():
+    """Existing color_category callers keep the same serialized API shape."""
+    chart = LineChart(
+        title="Legacy line colors",
+        color_category={"sales": "#ff0000", "profit": "#00ff00"},
+    )
+
+    visualize = chart.serialize_model()["metadata"]["visualize"]
+
+    assert visualize["color-category"] == {
+        "map": {"sales": "#ff0000", "profit": "#00ff00"}
+    }
+
+
+def test_matching_line_color_and_color_category_are_allowed():
+    """Callers may use both interfaces if overlapping values agree."""
+    chart = LineChart(
+        title="Matching colors",
+        color_category={"sales": "#ff0000", "profit": "#00ff00"},
+        lines=[Line(column="sales", color="#ff0000")],
+    )
+
+    visualize = chart.serialize_model()["metadata"]["visualize"]
+
+    assert visualize["color-category"] == {
+        "map": {"sales": "#ff0000", "profit": "#00ff00"}
+    }
+
+
+def test_conflicting_line_color_and_color_category_raise():
+    """Ambiguous colors should fail rather than silently picking a winner."""
+    chart = LineChart(
+        title="Conflicting colors",
+        color_category={"sales": "#ff0000"},
+        lines=[Line(column="sales", color="#00ff00")],
+    )
+
+    with pytest.raises(ValueError, match="Conflicting colors for line 'sales'"):
+        chart.serialize_model()
+
+
+def test_line_color_does_not_mutate_color_category_attribute():
+    """The convenience merge is serialization-only and leaves public state intact."""
+    chart = LineChart(
+        title="No mutation",
+        color_category={"profit": "#00ff00"},
+        lines=[Line(column="sales", color="#ff0000")],
+    )
+
+    chart.serialize_model()
+
+    assert chart.color_category == {"profit": "#00ff00"}
+
+
+def test_deserialization_keeps_colors_on_legacy_color_category():
+    """Color-category remains the canonical read-back location."""
+    init_data = LineChart.deserialize_model(
+        {
+            "type": "d3-lines",
+            "metadata": {
+                "visualize": {
+                    "color-category": {"map": {"sales": "#ff0000"}},
+                    "lines": {"sales": {"width": "style2"}},
+                }
+            },
+        }
+    )
+
+    assert init_data["color_category"] == {"sales": "#ff0000"}
+    assert init_data["lines"][0]["column"] == "sales"
+    assert "color" not in init_data["lines"][0]

--- a/tests/unit/models/test_line_color.py
+++ b/tests/unit/models/test_line_color.py
@@ -34,6 +34,28 @@ def test_line_color_merges_into_color_category_serialization():
     assert "color" not in visualize["lines"]["sales"]
 
 
+def test_dict_line_color_is_validated_once_during_serialization(monkeypatch):
+    """Serialization reuses validated line configs for color and line output."""
+    call_count = 0
+    original_model_validate = Line.model_validate.__func__
+
+    def counting_model_validate(cls, obj):
+        nonlocal call_count
+        call_count += 1
+        return original_model_validate(cls, obj)
+
+    monkeypatch.setattr(Line, "model_validate", classmethod(counting_model_validate))
+
+    chart = LineChart(title="Dict line colors")
+    chart.lines.append({"column": "sales", "color": "#ff0000", "width": "style2"})
+
+    visualize = chart.serialize_model()["metadata"]["visualize"]
+
+    assert call_count == 1
+    assert visualize["color-category"] == {"map": {"sales": "#ff0000"}}
+    assert visualize["lines"]["sales"]["width"] == "style2"
+
+
 def test_legacy_color_category_serialization_is_unchanged():
     """Existing color_category callers keep the same serialized API shape."""
     chart = LineChart(


### PR DESCRIPTION
## Summary
- Adds `Line.color` as a Line-centric convenience for line chart colors.
- Keeps `LineChart.color_category` as the canonical serialized/read-back API and preserves its existing `color-category` output shape.
- Merges `Line.color` values into the chart-level color map at serialization time, while rejecting conflicting `Line.color`/`color_category` values for the same line instead of silently choosing one.
- Updates the line chart docs to show the new convenience API and explain the compatibility relationship.

Fixes #479.

## Compatibility and migration
Existing callers using `color_category={"series": "#hex"}` do not need to change; serialization remains `metadata.visualize["color-category"] = {"map": ...}`. New code can put a color beside the rest of a line's styling with `Line(column="series", color="#hex")`. Deserialization continues to preserve colors on `LineChart.color_category` rather than duplicating them onto `Line` objects, so read-back behavior stays compatible with existing callers.

## Validation
- `uv run --extra test pytest tests/unit/models/test_line_color.py tests/integration/test_line_chart.py -q`
- `uv run --extra dev ruff check datawrapper/charts/line.py tests/unit/models/test_line_color.py tests/integration/test_line_chart.py docs/user-guide/charts/line-charts.md`
- `uv run --extra dev ruff format --check datawrapper/charts/line.py tests/unit/models/test_line_color.py tests/integration/test_line_chart.py`
- `uv run --extra test pytest tests/unit tests/integration -q`
- `uv run --extra test pytest -q` (1103 passed, 3 skipped)
