### PR TITLE
Add flat BaseChart transformation fields

### DIFF
--- a/datawrapper/charts/base.py
+++ b/datawrapper/charts/base.py
@@ -9,7 +9,27 @@ from IPython.display import IFrame
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from datawrapper.__main__ import Datawrapper
-from datawrapper.charts.models import Annotate, Describe, Publish, Transform, Visualize
+from datawrapper.charts.models import (
+    Annotate,
+    ColumnFormatList,
+    DataChangeList,
+    Describe,
+    Publish,
+    Transform,
+    Visualize,
+)
+
+TRANSFORMATION_FIELD_NAMES = (
+    "transpose",
+    "vertical_header",
+    "horizontal_header",
+    "column_order",
+    "column_format",
+    "changes",
+    "external_data",
+    "use_datawrapper_cdn",
+    "upload_method",
+)
 
 
 class BaseChart(BaseModel):
@@ -89,8 +109,91 @@ class BaseChart(BaseModel):
         default_factory=list[dict], description="The data to use for the chart"
     )
 
-    #: The metadata options for the data columns in the "Check and Describe" tab
+    #: The metadata options for the data columns in the "Check and Describe" tab.
+    #: Advanced callers can continue to pass the nested Datawrapper API-shaped
+    #: ``Transform`` model or dictionary here. The top-level fields below are
+    #: ergonomic aliases for the same supported transformation settings.
     transformations: Transform | dict[str, Any] = Field(default_factory=Transform)
+
+    #: Whether to transpose the data before visualization. Mirrors
+    #: ``transformations.transpose``.
+    transpose: bool | None = Field(
+        default=None,
+        exclude=True,
+        description="Whether to transpose the data before visualization",
+    )
+
+    #: Whether Datawrapper treats the first column as a vertical header. Mirrors
+    #: ``transformations.vertical_header``.
+    vertical_header: bool | None = Field(
+        default=None,
+        alias="vertical-header",
+        exclude=True,
+        description="Whether Datawrapper treats the first column as a vertical header",
+    )
+
+    #: Whether Datawrapper treats the first row as a horizontal header. Mirrors
+    #: ``transformations.horizontal_header``.
+    horizontal_header: bool | None = Field(
+        default=None,
+        alias="horizontal-header",
+        exclude=True,
+        description="Whether Datawrapper treats the first row as a horizontal header",
+    )
+
+    #: The order of data columns by zero-based index. Mirrors
+    #: ``transformations.column_order``.
+    column_order: list[int] | None = Field(
+        default=None,
+        alias="column-order",
+        exclude=True,
+        description="The order of data columns by zero-based index",
+    )
+
+    #: Formatting options for data columns. Accepts the same inputs as
+    #: ``Transform.column_format``: a ``ColumnFormatList``, a list of
+    #: ``ColumnFormat`` objects/dicts, or an API-shaped dict keyed by column name.
+    column_format: ColumnFormatList | list[Any] | dict[str, Any] | None = Field(
+        default=None,
+        alias="column-format",
+        exclude=True,
+        description="Formatting options for data columns",
+    )
+
+    #: Individual value corrections made in the Check & Describe tab. Accepts the
+    #: same list or API object-map inputs as ``Transform.changes``.
+    changes: DataChangeList | list[Any] | dict[str, Any] | None = Field(
+        default=None,
+        exclude=True,
+        description="Individual value corrections made in the Check & Describe tab",
+    )
+
+    #: External data source URL. Mirrors ``transformations.external_data``.
+    external_data: str | None = Field(
+        default=None,
+        alias="external-data",
+        exclude=True,
+        description="External data source URL",
+    )
+
+    #: Whether the external data URL should use the Datawrapper CDN. Mirrors
+    #: ``transformations.use_datawrapper_cdn``.
+    use_datawrapper_cdn: bool | None = Field(
+        default=None,
+        alias="use-datawrapper-cdn",
+        exclude=True,
+        description="Whether the external data URL should use the Datawrapper CDN",
+    )
+
+    #: Data upload method. Mirrors ``transformations.upload_method``.
+    upload_method: (
+        Literal["copy", "upload", "google-spreadsheet", "external-data"] | None
+    ) = Field(
+        default=None,
+        alias="upload-method",
+        exclude=True,
+        description="Data upload method",
+    )
 
     #
     # Description
@@ -284,11 +387,7 @@ class BaseChart(BaseModel):
             dw_obj["theme"] = self.theme
 
         # Set the transformations
-        data_section = (
-            self.transformations
-            if isinstance(self.transformations, Transform)
-            else Transform.model_validate(self.transformations)
-        ).model_dump(by_alias=True)
+        data_section = self._merged_transformations().model_dump(by_alias=True)
 
         # Validate the Describe data
         describe = Describe.model_validate(
@@ -430,7 +529,7 @@ class BaseChart(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def convert_column_format_dicts(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Convert dictionary items in transformation to Transform objects."""
+        """Convert transformation dictionaries to Transform objects before merging."""
         if not isinstance(data, dict):
             return data
 
@@ -438,6 +537,93 @@ class BaseChart(BaseModel):
             data["transformations"] = Transform.model_validate(data["transformations"])
 
         return data
+
+    @model_validator(mode="after")
+    def validate_flat_transformation_conflicts(self):
+        """Reject conflicting flat/nested transformation inputs early."""
+        object.__setattr__(self, "transformations", self._merged_transformations())
+        return self
+
+    @staticmethod
+    def _is_empty_transformation_value(field_name: str, value: Any) -> bool:
+        """Return whether a nested transform value represents its unset default."""
+        if field_name in {"column_order", "column_format", "changes"}:
+            return not bool(value)
+        if field_name in {"external_data"}:
+            return value == ""
+        return False
+
+    @staticmethod
+    def _normalized_transform_value(field_name: str, value: Any) -> Any:
+        """Normalize a transformation value for conflict comparison."""
+        if field_name == "column_format":
+            return ColumnFormatList.model_validate(value).model_dump(by_alias=True)
+        if field_name == "changes":
+            return DataChangeList.model_validate(value).model_dump(by_alias=True)
+        return value
+
+    @staticmethod
+    def _coerce_transform_value(field_name: str, value: Any) -> Any:
+        """Coerce flat values to the nested Transform field type before assignment."""
+        if field_name == "column_format":
+            return ColumnFormatList.model_validate(value)
+        if field_name == "changes":
+            return DataChangeList.model_validate(value)
+        return value
+
+    def _flat_transformation_values(self) -> dict[str, Any]:
+        """Collect top-level transformation convenience fields explicitly set by users."""
+        flat_values: dict[str, Any] = {}
+        for field_name in TRANSFORMATION_FIELD_NAMES:
+            if field_name in self.model_fields_set:
+                value = getattr(self, field_name)
+                if value is not None:
+                    flat_values[field_name] = value
+        return flat_values
+
+    def _merged_transformations(self) -> Transform:
+        """Merge top-level transformation fields into the nested Transform model.
+
+        The nested ``transformations`` object remains the source of truth for the
+        lower-level API. Flat fields fill unset/default nested values. If the same
+        setting is supplied in both places with different non-empty values, raise a
+        clear validation error instead of silently choosing one.
+        """
+        transform = (
+            self.transformations
+            if isinstance(self.transformations, Transform)
+            else Transform.model_validate(self.transformations)
+        )
+        flat_values = self._flat_transformation_values()
+        if not flat_values:
+            return transform
+
+        merged = transform.model_copy(deep=True)
+        for field_name, flat_value in flat_values.items():
+            nested_value = getattr(merged, field_name)
+            normalized_flat = self._normalized_transform_value(field_name, flat_value)
+            normalized_nested = self._normalized_transform_value(
+                field_name, nested_value
+            )
+
+            if (
+                field_name in transform.model_fields_set
+                and not self._is_empty_transformation_value(field_name, nested_value)
+                and normalized_flat != normalized_nested
+            ):
+                raise ValueError(
+                    f"Conflicting transformation values for '{field_name}'. "
+                    "Pass it either as a top-level BaseChart field or inside "
+                    "transformations, not both with different values."
+                )
+
+            setattr(
+                merged,
+                field_name,
+                self._coerce_transform_value(field_name, flat_value),
+            )
+
+        return merged
 
     @classmethod
     def deserialize_data(cls, csv_data: str | pd.DataFrame) -> pd.DataFrame:

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ caption: Advanced usage
 user-guide/advanced/authentication-and-account.md
 user-guide/advanced/organization.md
 user-guide/advanced/chart-operations.md
+user-guide/advanced/transformations.md
 user-guide/advanced/exporting.md
 ```
 

--- a/docs/user-guide/advanced/transformations.md
+++ b/docs/user-guide/advanced/transformations.md
@@ -1,0 +1,132 @@
+# Data transformations
+
+Datawrapper stores Check & Describe transformation settings under `metadata.data`.
+The object-oriented chart API exposes those settings in two compatible ways:
+
+1. Pass the nested `transformations=` argument for full API-shaped control.
+2. Pass supported transformation settings directly to a chart as top-level keyword
+   arguments when you only need the common cases.
+
+The flat fields are a small ergonomic layer over the existing `Transform` model.
+They do not replace `Transform`, and they serialize to the same
+`metadata.data` payload that Datawrapper expects.
+
+## Flat transformation fields
+
+Use top-level fields when you want to set one or two data transformations without
+constructing a nested `dw.Transform(...)` object:
+
+```python
+chart = dw.AreaChart(
+    title="Migration to the US by world region, 1820-2009",
+    data=df,
+    transpose=True,
+)
+```
+
+The supported flat fields match the current `Transform` model:
+
+- `transpose`
+- `vertical_header` / `vertical-header`
+- `horizontal_header` / `horizontal-header`
+- `column_order` / `column-order`
+- `column_format` / `column-format`
+- `changes`
+- `external_data` / `external-data`
+- `use_datawrapper_cdn` / `use-datawrapper-cdn`
+- `upload_method` / `upload-method`
+
+`column_format` accepts the same inputs as `Transform.column_format`: a list of
+`dw.ColumnFormat` objects or dictionaries, or an API-shaped dictionary keyed by
+column name. For example:
+
+```python
+chart = dw.LineChart(
+    title="Global land temperature in July, 1753-2015",
+    data=df,
+    column_format=[
+        dw.ColumnFormat(
+            column="LandAverageTemperature",
+            number_append=" °C",
+        )
+    ],
+)
+```
+
+Real Datawrapper API responses and Datawrapper Academy examples often represent
+`metadata.data.column-format` as a dictionary keyed by column name. That shape can
+also be used at the top level:
+
+```python
+chart = dw.LineChart(
+    title="Global land temperature in July, 1753-2015",
+    data=df,
+    column_format={
+        "LandAverageTemperature": {
+            "type": "auto",
+            "ignore": False,
+            "number-append": " °C",
+            "number-format": "-",
+            "number-divisor": 0,
+            "number-prepend": "",
+        }
+    },
+)
+```
+
+## When to use `Transform`
+
+Keep using the nested `transformations=` argument when you are round-tripping API
+metadata, preserving advanced Datawrapper response shapes, or grouping multiple
+data settings explicitly:
+
+```python
+chart = dw.BarChart(
+    title="Corrected values",
+    data=df,
+    transformations=dw.Transform(
+        changes=[
+            dw.DataChange(
+                row=9,
+                column=3,
+                value="1.7",
+                time=1573134075869,
+                previous="0.7",
+            )
+        ]
+    ),
+)
+```
+
+## Combining flat and nested forms
+
+Flat fields compose with `transformations=` by filling settings that are not set
+inside the nested `Transform` object:
+
+```python
+chart = dw.LineChart(
+    title="Formatted and reordered",
+    data=df,
+    transformations=dw.Transform(column_order=[0, 2, 1]),
+    column_format=[dw.ColumnFormat(column="sales", type="number")],
+)
+```
+
+If both forms provide the same setting, matching values are accepted. Conflicting
+values raise a validation error so the chart does not silently choose one source
+over the other:
+
+```python
+# Raises a validation error: transpose is True in one place and False in another.
+chart = dw.LineChart(
+    title="Conflicting settings",
+    data=df,
+    transformations=dw.Transform(transpose=True),
+    transpose=False,
+)
+```
+
+For API-loaded charts, Datawrapper metadata continues to deserialize into the
+nested `transformations` model. The flat fields are intended as construction-time
+conveniences and are omitted from `model_dump()`; serialization always writes the
+merged result to `metadata.data`.

--- a/docs/user-guide/charts/area-charts.md
+++ b/docs/user-guide/charts/area-charts.md
@@ -26,8 +26,9 @@ chart = dw.AreaChart(
     byline="Mirko Lorenz",
     # The DataFrame containing the source data
     data=df,
-    # Transpose the data with a transformation
-    transformations=dict(transpose=True),
+    # Transpose the data with the high-level transformation shortcut.
+    # Use transformations=dw.Transform(...) when you need the nested API shape.
+    transpose=True,
     # Format x-axis labels as full years (e.g., "2020").
     # Alternatively, you could provide "YYYY" if you'd rather not use the DateFormat enum.
     x_grid_format=dw.DateFormat.YEAR_FULL,

--- a/docs/user-guide/charts/line-charts.md
+++ b/docs/user-guide/charts/line-charts.md
@@ -20,15 +20,14 @@ chart = dw.LineChart(
     source_url="http://berkeleyearth.org/data/",
     # Data from pandas DataFrame
     data=df,
-    # Set the suffix on our values
-    transformations=dw.Transform(
-        column_format=[
-            dw.ColumnFormat(
-                column="LandAverageTemperature",
-                number_append=" °C",
-            )
-        ]
-    ),
+    # Set the suffix on our values with the high-level transformation shortcut.
+    # Use transformations=dw.Transform(...) when you need the nested API shape.
+    column_format=[
+        dw.ColumnFormat(
+            column="LandAverageTemperature",
+            number_append=" °C",
+        )
+    ],
     # Set the range
     custom_range_y=[8, 21],
     # Format Y-axis grid labels with no decimal places
@@ -98,9 +97,7 @@ chart = dw.LineChart(
         dw.Line(column="lower", width=dw.LineWidth.INVISIBLE),
         dw.Line(column="upper", width=dw.LineWidth.INVISIBLE),
     ],
-    area_fills=[
-        dw.AreaFill(from_column="lower", to_column="upper", color="#cccccc")
-    ],
+    area_fills=[dw.AreaFill(from_column="lower", to_column="upper", color="#cccccc")],
 )
 ```
 

--- a/tests/unit/serializers/test_base_transformations.py
+++ b/tests/unit/serializers/test_base_transformations.py
@@ -1,0 +1,171 @@
+"""Tests for BaseChart's high-level transformation fields."""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+import datawrapper
+
+
+def serialized_data(chart: datawrapper.BaseChart) -> dict:
+    """Return the Datawrapper metadata.data section for a chart."""
+    return chart.serialize_model()["metadata"]["data"]
+
+
+def test_base_chart_accepts_flat_transformation_fields():
+    """Top-level fields serialize into metadata.data without a Transform wrapper."""
+    chart = datawrapper.BaseChart(
+        chart_type="d3-lines",
+        title="Flat transformations",
+        transpose=True,
+        column_order=[2, 1, 0],
+        column_format=[
+            datawrapper.ColumnFormat(
+                column="sales",
+                type="number",
+                number_prepend="$",
+            )
+        ],
+        changes=[
+            datawrapper.DataChange(
+                row=9,
+                column=3,
+                value="1.7",
+                time=1573134075869,
+                previous="0.7",
+            )
+        ],
+        external_data="https://example.com/data.csv",
+        use_datawrapper_cdn=False,
+        upload_method="external-data",
+    )
+
+    data = serialized_data(chart)
+
+    assert data["transpose"] is True
+    assert data["column-order"] == [2, 1, 0]
+    assert data["column-format"] == {"sales": {"type": "number", "number-prepend": "$"}}
+    assert data["changes"] == [
+        {
+            "row": 9,
+            "column": 3,
+            "value": "1.7",
+            "time": 1573134075869,
+            "previous": "0.7",
+        }
+    ]
+    assert data["external-data"] == "https://example.com/data.csv"
+    assert data["use-datawrapper-cdn"] is False
+    assert data["upload-method"] == "external-data"
+    assert chart.transformations.transpose is True
+    assert chart.transformations.column_order == [2, 1, 0]
+    assert chart.transformations.external_data == "https://example.com/data.csv"
+
+
+def test_flat_column_format_accepts_api_shaped_fixture():
+    """Real sample metadata.data column-format maps work at top level too.
+
+    The existing ColumnFormat serializer normalizes away default values from API
+    samples, so this asserts the substantive non-default setting is preserved.
+    """
+    fixture_path = Path(__file__).parents[2] / "samples" / "line" / "land-temps.json"
+    fixture = json.loads(fixture_path.read_text())
+    data = fixture["chart"]["crdt"]["data"]["metadata"]["data"]
+
+    chart = datawrapper.BaseChart(
+        chart_type="d3-lines",
+        title="Academy sample",
+        column_format=data["column-format"],
+    )
+
+    assert serialized_data(chart)["column-format"] == {
+        "LandAverageTemperature": {"number-append": " °C"}
+    }
+
+
+def test_flat_transformation_fields_compose_with_nested_defaults():
+    """Flat values can fill unset/default nested Transform settings."""
+    chart = datawrapper.BaseChart(
+        chart_type="d3-lines",
+        title="Composed transformations",
+        transformations=datawrapper.Transform(column_order=[0, 1, 2]),
+        column_format=[{"column": "sales", "type": "number"}],
+    )
+
+    data = serialized_data(chart)
+
+    assert data["column-order"] == [0, 1, 2]
+    assert data["column-format"] == {"sales": {"type": "number"}}
+
+
+def test_matching_flat_and_nested_transformation_values_are_accepted():
+    """Supplying both forms is okay when the overlapping values match."""
+    chart = datawrapper.BaseChart(
+        chart_type="d3-lines",
+        title="Matching transformations",
+        transformations={"transpose": True},
+        transpose=True,
+    )
+
+    assert chart.transformations.transpose is True
+    assert serialized_data(chart)["transpose"] is True
+
+
+def test_flat_transformation_assignment_updates_nested_transformations():
+    """Assignment keeps updates and serialization pointed at metadata.data."""
+    chart = datawrapper.BaseChart(
+        chart_type="d3-lines",
+        title="Updated transformations",
+    )
+
+    chart.transpose = True
+    chart.column_order = [1, 0]
+
+    assert chart.transformations.transpose is True
+    assert chart.transformations.column_order == [1, 0]
+    assert serialized_data(chart)["transpose"] is True
+    assert serialized_data(chart)["column-order"] == [1, 0]
+
+
+def test_conflicting_flat_and_nested_transformation_values_raise_validation_error():
+    """Conflicts fail instead of silently preferring flat or nested input."""
+    with pytest.raises(ValidationError, match="Conflicting transformation values"):
+        datawrapper.BaseChart(
+            chart_type="d3-lines",
+            title="Conflicting transformations",
+            transformations={"transpose": True},
+            transpose=False,
+        )
+
+
+def test_api_response_deserialization_keeps_nested_transform_only():
+    """API-shaped input remains represented by transformations for round trips."""
+    api_response = {
+        "id": "abc123",
+        "type": "d3-lines",
+        "title": "API chart",
+        "language": "en-US",
+        "theme": "datawrapper",
+        "metadata": {
+            "data": {
+                "transpose": True,
+                "vertical-header": True,
+                "horizontal-header": True,
+                "column-format": {"sales": {"type": "number"}},
+                "upload-method": "copy",
+            },
+            "describe": {},
+            "annotate": {},
+            "visualize": {},
+            "publish": {"blocks": {}},
+        },
+    }
+
+    parsed = datawrapper.BaseChart.deserialize_model(api_response)
+    chart = datawrapper.BaseChart(**parsed)
+
+    assert chart.transpose is None
+    assert chart.transformations.transpose is True
+    assert serialized_data(chart)["column-format"] == {"sales": {"type": "number"}}


### PR DESCRIPTION
## Summary

- Adds top-level `BaseChart` transformation fields (`transpose`, `column_order`, `column_format`, `changes`, external-data settings, etc.) as a narrow ergonomic layer over the existing `Transform` model.
- Keeps the nested `transformations=` API intact and merges flat fields into the same `metadata.data` serialization shape Datawrapper expects.
- Raises a validation error when callers provide conflicting flat and nested values for the same transformation; matching duplicate values are accepted.
- Adds focused docs and examples showing when to use the flat shortcuts vs. `dw.Transform(...)`.

## Compatibility design

The nested `transformations` model remains the source of truth for API-shaped data and round trips. Flat fields are `exclude=True` Pydantic fields, so `model_dump()` does not introduce a second representation; construction and assignment merge them into `chart.transformations`, and `serialize_model()` writes the merged result under `metadata.data`.

Supported flat fields are intentionally limited to the current `Transform` model: `transpose`, `vertical_header`, `horizontal_header`, `column_order`, `column_format`, `changes`, `external_data`, `use_datawrapper_cdn`, and `upload_method`.

Closes #499.

## Validation

- `uv run pytest tests/unit/serializers/test_base_transformations.py -q`
- `uv run pytest tests/unit/serializers/test_base_transformations.py tests/unit/models/test_transform.py tests/unit/serializers/test_base_serializer.py tests/integration/test_base_metadata_structure.py -q`
- `uv run ruff check ./datawrapper ./tests`
- `uv run ruff format --check ./datawrapper ./tests`
- `uv run mypy ./datawrapper --ignore-missing-imports`
- `uv run pre-commit run --all-files`
- `uv run pytest` — 1127 passed, 3 skipped
- `uv build --sdist --wheel`
